### PR TITLE
Segmented* fixes

### DIFF
--- a/urbansim/models/lcm.py
+++ b/urbansim/models/lcm.py
@@ -566,6 +566,8 @@ class SegmentedMNLLocationChoiceModel(object):
         the alternatives index is used.
     default_model_expr : str, iterable, or dict, optional
         A patsy model expression. Should contain only a right-hand side.
+    name : str, optional
+        An optional string used to identify the model in places.
 
     """
     def __init__(self, segmentation_col, sample_size,
@@ -573,7 +575,7 @@ class SegmentedMNLLocationChoiceModel(object):
                  alts_fit_filters=None, alts_predict_filters=None,
                  interaction_predict_filters=None,
                  estimation_sample_size=None,
-                 choice_column=None, default_model_expr=None):
+                 choice_column=None, default_model_expr=None, name=None):
         self.segmentation_col = segmentation_col
         self.sample_size = sample_size
         self.choosers_fit_filters = choosers_fit_filters
@@ -585,6 +587,8 @@ class SegmentedMNLLocationChoiceModel(object):
         self.choice_column = choice_column
         self.default_model_expr = default_model_expr
         self._group = MNLLocationChoiceModelGroup(segmentation_col)
+        self.name = (name if name is not None else
+                     'SegmentedMNLLocationChoiceModel')
 
     @classmethod
     def from_yaml(cls, yaml_str=None, str_or_buffer=None):
@@ -618,7 +622,8 @@ class SegmentedMNLLocationChoiceModel(object):
             cfg['interaction_predict_filters'],
             cfg['estimation_sample_size'],
             cfg['choice_column'],
-            default_model_expr)
+            default_model_expr,
+            cfg['name'])
 
         if "models" not in cfg:
             cfg["models"] = {}
@@ -802,6 +807,7 @@ class SegmentedMNLLocationChoiceModel(object):
         """
         return {
             'model_type': 'segmented_locationchoice',
+            'name': self.name,
             'segmentation_col': self.segmentation_col,
             'sample_size': self.sample_size,
             'choosers_fit_filters': self.choosers_fit_filters,

--- a/urbansim/models/regression.py
+++ b/urbansim/models/regression.py
@@ -589,12 +589,16 @@ class SegmentedRegressionModel(object):
         the results reflect actual price.
 
         By default no transformation is applied.
+    min_segment_size : int, optional
+        Segments with less than this many members will be skipped.
+    name : str, optional
+        A name used in places to identify the model.
 
     """
     def __init__(
             self, segmentation_col, fit_filters=None, predict_filters=None,
             default_model_expr=None, default_ytransform=None,
-            min_segment_size=0):
+            min_segment_size=0, name=None):
         self.segmentation_col = segmentation_col
         self._group = RegressionModelGroup(segmentation_col)
         self.fit_filters = fit_filters
@@ -602,6 +606,7 @@ class SegmentedRegressionModel(object):
         self.default_model_expr = default_model_expr
         self.default_ytransform = default_ytransform
         self.min_segment_size = min_segment_size
+        self.name = name if name is not None else 'SegmentedRegressionModel'
 
     @classmethod
     def from_yaml(cls, yaml_str=None, str_or_buffer=None):
@@ -629,7 +634,8 @@ class SegmentedRegressionModel(object):
         seg = cls(
             cfg['segmentation_col'], cfg['fit_filters'],
             cfg['predict_filters'], default_model_expr,
-            YTRANSFORM_MAPPING[default_ytransform])
+            YTRANSFORM_MAPPING[default_ytransform], cfg['min_segment_size'],
+            cfg['name'])
 
         if "models" not in cfg:
             cfg["models"] = {}
@@ -784,9 +790,11 @@ class SegmentedRegressionModel(object):
         """
         return {
             'model_type': 'segmented_regression',
+            'name': self.name,
             'segmentation_col': self.segmentation_col,
             'fit_filters': self.fit_filters,
             'predict_filters': self.predict_filters,
+            'min_segment_size': self.min_segment_size,
             'default_config': {
                 'model_expression': self.default_model_expr,
                 'ytransform': YTRANSFORM_MAPPING[self.default_ytransform]

--- a/urbansim/models/tests/test_lcm.py
+++ b/urbansim/models/tests/test_lcm.py
@@ -194,12 +194,13 @@ def test_mnl_lcm_segmented_yaml(grouped_choosers, alternatives):
     sample_size = 4
 
     group = lcm.SegmentedMNLLocationChoiceModel(
-        'group', sample_size, default_model_expr=model_exp)
+        'group', sample_size, default_model_expr=model_exp, name='test_seg')
     group.add_segment('x')
     group.add_segment('y', 'var3 + var1:var2')
 
     expected_dict = {
         'model_type': 'segmented_locationchoice',
+        'name': 'test_seg',
         'segmentation_col': 'group',
         'sample_size': sample_size,
         'choosers_fit_filters': None,

--- a/urbansim/models/tests/test_regression.py
+++ b/urbansim/models/tests/test_regression.py
@@ -320,15 +320,18 @@ def test_SegmentedRegressionModel_explicit(groupby_df):
 def test_SegmentedRegressionModel_yaml(groupby_df):
     seg = regression.SegmentedRegressionModel(
         'group', fit_filters=['col1 not in [2]'],
-        predict_filters=['group != "z"'], default_model_expr='col1 ~ col2')
+        predict_filters=['group != "z"'], default_model_expr='col1 ~ col2',
+        min_segment_size=5000, name='test_seg')
     seg.add_segment('x')
     seg.add_segment('y', 'np.exp(col2) ~ np.exp(col1)', np.log)
 
     expected_dict = {
         'model_type': 'segmented_regression',
+        'name': 'test_seg',
         'segmentation_col': 'group',
         'fit_filters': ['col1 not in [2]'],
         'predict_filters': ['group != "z"'],
+        'min_segment_size': 5000,
         'default_config': {
             'model_expression': 'col1 ~ col2',
             'ytransform': None


### PR DESCRIPTION
`Segmented*` models will now clear stored models for segments that do not exist on the incoming fit data. Also added `.name` attributes.
