### PR TITLE
__getitem__ and __getattr__ for frame wrappers

### DIFF
--- a/urbansim/sim/tests/test_simulation.py
+++ b/urbansim/sim/tests/test_simulation.py
@@ -33,15 +33,21 @@ def test_tables(df, clear_sim):
     assert set(sim.list_tables()) == {'test_frame', 'test_func'}
 
     table = sim.get_table('test_frame')
+    assert table.columns == ['a', 'b']
     pdt.assert_index_equal(table.index, df.index)
     pdt.assert_series_equal(table.get_column('a'), df.a)
     pdt.assert_series_equal(table.a, df.a)
     pdt.assert_series_equal(table['b'], df['b'])
 
     table = sim.get_table('test_func')
-
+    assert table.index is None
+    assert table.columns == []
     pdt.assert_frame_equal(table.to_frame(), df / 2)
     pdt.assert_frame_equal(table.to_frame(columns=['a']), df[['a']] / 2)
+    pdt.assert_index_equal(table.index, df.index)
+    pdt.assert_series_equal(table.get_column('a'), df.a / 2)
+    pdt.assert_series_equal(table.a, df.a / 2)
+    pdt.assert_series_equal(table['b'], df['b'] / 2)
 
 
 def test_columns_for_table(clear_sim):


### PR DESCRIPTION
Adds the ability to quickly pull individual columns off of wrapped tables as regular pandas Series objects. The new `.get_column` method may also be used.
