### PR TITLE
Transition model- handle agent segments of length zero and certain control total conventions

### DIFF
--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -284,6 +284,12 @@ class TabularGrowthRateTransition(object):
 
         for _, row in year_config.iterrows():
             subset = util.filter_table(data, row, ignore={self._config_column})
+
+            # Do not run on segment if it is empty
+            if len(subset) == 0:
+                logger.debug('empty segment encountered')
+                continue
+
             nrows = self._calc_nrows(len(subset), row[self._config_column])
             updated, added, copied, removed = \
                 add_or_remove_rows(subset, nrows, starting_index)

--- a/urbansim/models/util.py
+++ b/urbansim/models/util.py
@@ -119,6 +119,7 @@ def filter_table(table, filter_series, ignore=None):
                    if not (name in ignore or
                            (isinstance(val, numbers.Number) and
                             np.isnan(val)))]
+
         return apply_filter_query(table, filters)
 
 


### PR DESCRIPTION
Control totals tables that are heavily segmented may imply agent types that do not exist.  Instead of stopping the simulation, we can log a message notifying the user of the nonexistence, then continue.  Also, certain changes were made to the _filterize function in utils so as to handle existing urbansim conventions regarding control total table format.  These changes were motivated by use of SEMCOG's household control totals in full detail.
