### PR TITLE
Injectables and table sources

### DIFF
--- a/urbansim/sim/tests/test_simulation.py
+++ b/urbansim/sim/tests/test_simulation.py
@@ -277,3 +277,21 @@ def test_injectables_combined(clear_sim, df):
 
     pdt.assert_frame_equal(table[['a', 'b']], df)
     pdt.assert_series_equal(table['new'], column())
+
+
+def test_table_source(clear_sim, df):
+    @sim.table_source('source')
+    def source():
+        return df
+
+    table = sim.get_table('source')
+    assert isinstance(table, sim._TableSourceWrapper)
+
+    test_df = table.to_frame()
+    pdt.assert_frame_equal(test_df, df)
+
+    table = sim.get_table('source')
+    assert isinstance(table, sim._DataFrameWrapper)
+
+    test_df = table.to_frame()
+    pdt.assert_frame_equal(test_df, df)


### PR DESCRIPTION
This adds two ideas to the simulation framework:

Injectables are basically naked values (numbers, strings, anything) that are injected into table/model/column functions just as tables are now. They are injected with no wrapping. If you make a function injectable, then by default the function is evaluated (with its own injection) and its return value injected, but you can turn that off so the function itself is injected.

Examples:

``` python
sim.add_injectable('answer', 42)

@sim.injectable('answer')
def answer():
    return 42

# div2 function itself will be injected, no dependency injection happens here
@sim.injectable('div2', autocall=False)
def div2(x):
    return x / 2
```

The other new thing is table sources. These are functions that return DataFrames, but the registered function is replaced by the returned DataFrame the first time the function is called (so the function is only ever called once).

Examples:

``` python
@sim.table_source('source')
def source():
    return store['buildings']
```
