### PR TITLE
Add ability to get local columns from wrapped functions

### DIFF
--- a/urbansim/sim/simulation.py
+++ b/urbansim/sim/simulation.py
@@ -32,7 +32,7 @@ class SimulationError(Exception):
     pass
 
 
-class _DataFrameWrapper(object):
+class DataFrameWrapper(object):
     """
     Wraps a DataFrame so it can provide certain columns and handle
     computed columns.
@@ -144,7 +144,7 @@ class _DataFrameWrapper(object):
         return len(self._frame)
 
 
-class _TableFuncWrapper(object):
+class TableFuncWrapper(object):
     """
     Wrap a function that provides a DataFrame.
 
@@ -224,7 +224,7 @@ class _TableFuncWrapper(object):
 
         """
         frame = self._call_func()
-        return _DataFrameWrapper(self.name, frame).to_frame(columns)
+        return DataFrameWrapper(self.name, frame).to_frame(columns)
 
     def get_column(self, column_name):
         """
@@ -251,7 +251,7 @@ class _TableFuncWrapper(object):
         return self._len
 
 
-class _TableSourceWrapper(_TableFuncWrapper):
+class TableSourceWrapper(TableFuncWrapper):
     """
     Wraps a function that returns a DataFrame. After the function
     is evaluated the returned DataFrame replaces the function in the
@@ -266,7 +266,7 @@ class _TableSourceWrapper(_TableFuncWrapper):
     def convert(self):
         """
         Evaluate the wrapped function, store the returned DataFrame as a
-        table, and return the new _DataFrameWrapper instance created.
+        table, and return the new DataFrameWrapper instance created.
 
         """
         frame = self._call_func()
@@ -430,13 +430,13 @@ def add_table(table_name, table):
 
     Returns
     -------
-    wrapped : `_DataFrameWrapper` or `_TableFuncWrapper`
+    wrapped : `DataFrameWrapper` or `TableFuncWrapper`
 
     """
     if isinstance(table, pd.DataFrame):
-        table = _DataFrameWrapper(table_name, table)
+        table = DataFrameWrapper(table_name, table)
     elif isinstance(table, Callable):
-        table = _TableFuncWrapper(table_name, table)
+        table = TableFuncWrapper(table_name, table)
     else:
         raise TypeError('table must be DataFrame or function.')
 
@@ -475,10 +475,10 @@ def add_table_source(table_name, func):
 
     Returns
     -------
-    wrapped : `_TableSourceWrapper`
+    wrapped : `TableSourceWrapper`
 
     """
-    wrapped = _TableSourceWrapper(table_name, func)
+    wrapped = TableSourceWrapper(table_name, func)
     _TABLES[table_name] = wrapped
     return wrapped
 
@@ -506,7 +506,7 @@ def get_table(table_name):
 
     Returns
     -------
-    table : _DataFrameWrapper or _TableFuncWrapper
+    table : `DataFrameWrapper`, `TableFuncWrapper`, or `TableSourceWrapper`
 
     """
     if table_name in _TABLES:
@@ -804,7 +804,7 @@ def merge_tables(target, tables, columns=None):
     ----------
     target : str
         Name of the table onto which tables will be merged.
-    tables : list of _DataFrameWrapper or _TableFuncWrapper
+    tables : list of `DataFrameWrapper` or `TableFuncWrapper`
         All of the tables to merge. Should include the target table.
     columns : list of str, optional
         If given, columns will be mapped to `tables` and only those columns

--- a/urbansim/sim/tests/test_mergetables.py
+++ b/urbansim/sim/tests/test_mergetables.py
@@ -9,7 +9,7 @@ from ...utils.testing import assert_frames_equal
 
 @pytest.fixture
 def dfa():
-    return sim._DataFrameWrapper('a', pd.DataFrame(
+    return sim.DataFrameWrapper('a', pd.DataFrame(
         {'a1': [1, 2, 3],
          'a2': [4, 5, 6],
          'a3': [7, 8, 9]},
@@ -18,7 +18,7 @@ def dfa():
 
 @pytest.fixture
 def dfz():
-    return sim._DataFrameWrapper('z', pd.DataFrame(
+    return sim.DataFrameWrapper('z', pd.DataFrame(
         {'z1': [90, 91],
          'z2': [92, 93],
          'z3': [94, 95],
@@ -29,7 +29,7 @@ def dfz():
 
 @pytest.fixture
 def dfb():
-    return sim._DataFrameWrapper('b', pd.DataFrame(
+    return sim.DataFrameWrapper('b', pd.DataFrame(
         {'b1': range(10, 15),
          'b2': range(15, 20),
          'a_id': ['ac', 'ac', 'ab', 'aa', 'ab'],
@@ -39,7 +39,7 @@ def dfb():
 
 @pytest.fixture
 def dfc():
-    return sim._DataFrameWrapper('c', pd.DataFrame(
+    return sim.DataFrameWrapper('c', pd.DataFrame(
         {'c1': range(20, 30),
          'c2': range(30, 40),
          'b_id': ['ba', 'bd', 'bb', 'bc', 'bb', 'ba', 'bb', 'bc', 'bd', 'bb']},
@@ -48,14 +48,14 @@ def dfc():
 
 @pytest.fixture
 def dfg():
-    return sim._DataFrameWrapper('g', pd.DataFrame(
+    return sim.DataFrameWrapper('g', pd.DataFrame(
         {'g1': [1, 2, 3]},
         index=['ga', 'gb', 'gc']))
 
 
 @pytest.fixture
 def dfh():
-    return sim._DataFrameWrapper('h', pd.DataFrame(
+    return sim.DataFrameWrapper('h', pd.DataFrame(
         {'h1': range(10, 15),
          'g_id': ['ga', 'gb', 'gc', 'ga', 'gb']},
         index=['ha', 'hb', 'hc', 'hd', 'he']))

--- a/urbansim/sim/tests/test_simulation.py
+++ b/urbansim/sim/tests/test_simulation.py
@@ -287,7 +287,7 @@ def test_table_source(clear_sim, df):
         return df
 
     table = sim.get_table('source')
-    assert isinstance(table, sim._TableSourceWrapper)
+    assert isinstance(table, sim.TableSourceWrapper)
 
     test_df = table.to_frame()
     pdt.assert_frame_equal(test_df, df)
@@ -296,7 +296,7 @@ def test_table_source(clear_sim, df):
     pdt.assert_index_equal(table.index, df.index)
 
     table = sim.get_table('source')
-    assert isinstance(table, sim._DataFrameWrapper)
+    assert isinstance(table, sim.DataFrameWrapper)
 
     test_df = table.to_frame()
     pdt.assert_frame_equal(test_df, df)
@@ -308,10 +308,10 @@ def test_table_source_convert(clear_sim, df):
         return df
 
     table = sim.get_table('source')
-    assert isinstance(table, sim._TableSourceWrapper)
+    assert isinstance(table, sim.TableSourceWrapper)
 
     table = table.convert()
-    assert isinstance(table, sim._DataFrameWrapper)
+    assert isinstance(table, sim.DataFrameWrapper)
     pdt.assert_frame_equal(table.to_frame(), df)
 
     table2 = sim.get_table('source')


### PR DESCRIPTION
The `.local_columns` attribute on all wrapped tables should now work.
On wrapped functions (both tables and sources), it will evaluate the
function, store frame metadata, and return the frame columns.

For table sources this will also cause the registered table source to be replaced with the data frame, but now the function wrapper object will have working `.columns`, `.local_columns`, `.index`, and `len()` capabilities.
