### PR TITLE
Convert TableSourceWrappers to DataFrameWrapper on injection

### DIFF
--- a/urbansim/sim/simulation.py
+++ b/urbansim/sim/simulation.py
@@ -449,10 +449,13 @@ def _collect_injectables(names):
             'not all injectables found. '
             'missing: {}'.format(names - set(dicts.keys())))
 
-    return {
-        name: thing
-        if not isinstance(thing, _InjectableFuncWrapper) else thing()
-        for name, thing in dicts.items()}
+    for name, thing in dicts.items():
+        if isinstance(thing, _InjectableFuncWrapper):
+            dicts[name] = thing()
+        elif isinstance(thing, TableSourceWrapper):
+            dicts[name] = thing.convert()
+
+    return dicts
 
 
 def add_table(table_name, table):

--- a/urbansim/sim/tests/test_simulation.py
+++ b/urbansim/sim/tests/test_simulation.py
@@ -230,13 +230,19 @@ def test_collect_injectables(clear_sim, df):
     def injected():
         return 'injected'
 
+    @sim.table_source('source')
+    def source():
+        return df
+
     with pytest.raises(KeyError):
         sim._collect_injectables(['asdf'])
 
-    names = ['df', 'df_func', 'answer', 'injected']
+    names = ['df', 'df_func', 'answer', 'injected', 'source']
     things = sim._collect_injectables(names)
 
     assert set(things.keys()) == set(names)
+    assert isinstance(things['source'], sim.DataFrameWrapper)
+    pdt.assert_frame_equal(things['source']._frame, df)
 
 
 def test_injectables(clear_sim):


### PR DESCRIPTION
This way users never have to bother with converting `TableSourceWrapper`
on their own, something that can be annoying for workflows.
