### PR TITLE
Have Travis Build Docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ install:
 - pip install simplejson bottle
 - pip install pytest-cov coveralls pep8
 - pip install .
-# before_script:
-# - git clone https://github.com/synthicity/sanfran_urbansim.git
-# - cd sanfran_urbansim; ipython nbconvert --to python Simulation.ipynb
-# - cd ..
+before_script:
+- git clone https://github.com/synthicity/sanfran_urbansim.git
+- cd sanfran_urbansim; ipython nbconvert --to python Simulation.ipynb
+- cd ..
 script:
 - pep8 urbansim scripts
-# - py.test --cov urbansim --cov-report term-missing
-# - cd sanfran_urbansim; python Simulation.py
-# - cd ..
+- py.test --cov urbansim --cov-report term-missing
+- cd sanfran_urbansim; python Simulation.py
+- cd ..
 after_success:
-# - coveralls
+- coveralls
 - bin/build_docs.sh
 notifications:
   slack:

--- a/bin/build_docs.sh
+++ b/bin/build_docs.sh
@@ -29,8 +29,8 @@ set -e
 ACTUAL_TRAVIS_JOB_NUMBER=`echo $TRAVIS_JOB_NUMBER| cut -d'.' -f 2`
 
 if [ "$TRAVIS_REPO_SLUG" == "synthicity/urbansim" ] && \
-        # [ "$TRAVIS_BRANCH" == "master"] && \
-        # [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
+        [ "$TRAVIS_BRANCH" == "master" ] && \
+        [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
         [ "$ACTUAL_TRAVIS_JOB_NUMBER" == "1" ]; then
 
         echo "Installing dependencies"


### PR DESCRIPTION
Travis will build the docs and post them to gh-pages when the following things are true:
- build is not from a pull request
- build is of the synthicity/urbansim repo
- build is for the `master` branch

I think this should result in doc builds most frequently from merged pull requests. We'll find out when we merge this one.
