### PR TITLE
Add tests of mnl with alternative-specific coefficients

### DIFF
--- a/urbansim/urbanchoice/tests/data/mnl_tests.R
+++ b/urbansim/urbanchoice/tests/data/mnl_tests.R
@@ -28,6 +28,14 @@ print(predict(mnl, newdata=fish_choosers))
 print('******************')
 print('******************')
 
+mnl = mlogit(mode ~ 0 | income, data=Fish)
+summary(mnl)
+print(mnl$coefficients)
+print(predict(mnl, newdata=fish_choosers))
+
+print('******************')
+print('******************')
+
 data('TravelMode', package='AER')
 TravelMode = mlogit.data(TravelMode, shape='long', choice='choice', varying=c(3:7), alt.var='mode')
 write.csv(TravelMode, file='travel_mode.csv')


### PR DESCRIPTION
Previous tests assumed that coefficients would be the same
across alternatives, so this adds a new test against R that
shows when we contstruct matrices in the same way R does
for alternative specific coefficients we get the same results.
