### PR TITLE
Fixing slow MNL estimation

### DIFF
--- a/urbansim/urbanchoice/interaction.py
+++ b/urbansim/urbanchoice/interaction.py
@@ -55,7 +55,7 @@ def mnl_interaction_dataset(choosers, alternatives, SAMPLE_SIZE,
     alts_idx = np.arange(len(alternatives))
     if SAMPLE_SIZE < numalts:
         sample = np.concatenate(tuple(
-            np.random.choice(alts_idx, SAMPLE_SIZE, replace=False)
+            np.random.choice(alts_idx, SAMPLE_SIZE, replace=True)
             for _ in range(numchoosers)))
 
         if chosenalts is not None:


### PR DESCRIPTION
Sampling choice alternatives for multinomial logit models **without** replacement (in other words, guaranteeing unique alternatives) turns out to increase the estimation time by a couple orders of magnitude. This update rolls back that change. In a typical use case, 100 alternatives are chosen from a pool of millions, so the effect on estimation output should be minimal.

This resolves [issue 65 from UDST/bayarea_urbansim](https://github.com/UDST/bayarea_urbansim/issues/65). I tested it by successfully estimating a location choice model, but don't know what other testing may be needed. 