### PR TITLE
Revert Alternative Sampling

### DIFF
--- a/urbansim/models/tests/test_dcm.py
+++ b/urbansim/models/tests/test_dcm.py
@@ -163,7 +163,7 @@ def test_mnl_dcm(seed, basic_dcm, choosers, alternatives):
     pdt.assert_series_equal(
         choices,
         pd.Series(
-            ['b', 'j', 'g'], index=pd.Index([1, 3, 4], name='chooser_id')))
+            ['h', 'c', 'f'], index=pd.Index([1, 3, 4], name='chooser_id')))
 
     # check that we can do a YAML round-trip
     yaml_str = basic_dcm.to_yaml()
@@ -245,7 +245,6 @@ def test_mnl_dcm_yaml(basic_dcm, choosers, alternatives):
 
 def test_mnl_dcm_prob_mode_single(seed, basic_dcm_fit, choosers, alternatives):
     basic_dcm_fit.probability_mode = 'single_chooser'
-    basic_dcm_fit.choice_mode = 'aggregate'
 
     filtered_choosers, filtered_alts = basic_dcm_fit.apply_predict_filters(
         choosers, alternatives)
@@ -255,15 +254,15 @@ def test_mnl_dcm_prob_mode_single(seed, basic_dcm_fit, choosers, alternatives):
     pdt.assert_series_equal(
         probs,
         pd.Series(
-            [0.33709756,
-             0.23459563,
-             0.16326167,
-             0.11361837,
-             0.05502717,
-             0.03829495,
-             0.02665053,
-             0.01854685,
-             0.01290727],
+            [0.25666709612190147,
+             0.20225620916965448,
+             0.15937989234214262,
+             0.1255929308043417,
+             0.077988133629030815,
+             0.061455420294827229,
+             0.04842747874412457,
+             0.038161332007195688,
+             0.030071506886781514],
             index=pd.MultiIndex.from_product(
                 [[1], filtered_alts.index.values],
                 names=['chooser_id', 'alternative_id'])))
@@ -277,7 +276,6 @@ def test_mnl_dcm_prob_mode_single(seed, basic_dcm_fit, choosers, alternatives):
 def test_mnl_dcm_prob_mode_single_prediction_sample_size(
         seed, basic_dcm_fit, choosers, alternatives):
     basic_dcm_fit.probability_mode = 'single_chooser'
-    basic_dcm_fit.choice_mode = 'aggregate'
     basic_dcm_fit.prediction_sample_size = 5
 
     filtered_choosers, filtered_alts = basic_dcm_fit.apply_predict_filters(
@@ -288,19 +286,19 @@ def test_mnl_dcm_prob_mode_single_prediction_sample_size(
     pdt.assert_series_equal(
         probs,
         pd.Series(
-            [0.06805838,
-             0.20192435,
-             0.022939,
-             0.29015121,
-             0.41692705],
+            [0.11137766,
+             0.05449957,
+             0.14134044,
+             0.22761617,
+             0.46516616],
             index=pd.MultiIndex.from_product(
-                [[1], ['f', 'c', 'i', 'b', 'a']],
+                [[1], ['g', 'j', 'f', 'd', 'a']],
                 names=['chooser_id', 'alternative_id'])))
 
     sprobs = basic_dcm_fit.summed_probabilities(choosers, alternatives)
     pdt.assert_index_equal(
         sprobs.index,
-        pd.Index(['j', 'b', 'g', 'h', 'd'], name='alternative_id'))
+        pd.Index(['d', 'g', 'a', 'c', 'd'], name='alternative_id'))
     npt.assert_allclose(sprobs.sum(), len(filtered_choosers))
 
 
@@ -333,7 +331,7 @@ def test_mnl_dcm_choice_mode_agg(seed, basic_dcm_fit, choosers, alternatives):
 
     pdt.assert_series_equal(
         choices,
-        pd.Series(['a', 'c', 'b', 'd'], index=[0, 1, 3, 4]))
+        pd.Series(['f', 'a', 'd', 'c'], index=[0, 1, 3, 4]))
 
 
 def test_mnl_dcm_group(seed, grouped_choosers, alternatives):
@@ -382,7 +380,7 @@ def test_mnl_dcm_group(seed, grouped_choosers, alternatives):
     pdt.assert_series_equal(
         choices,
         pd.Series(
-            ['c', 'e', 'c', 'i'],
+            ['c', 'a', 'a', 'g'],
             index=pd.Index([0, 3, 1, 4], name='chooser_id')))
 
     # check that we don't get the same alt twice if they are removed
@@ -394,7 +392,7 @@ def test_mnl_dcm_group(seed, grouped_choosers, alternatives):
     pdt.assert_series_equal(
         choices,
         pd.Series(
-            ['c', 'e', 'd', 'i'],
+            ['c', 'a', 'b', 'g'],
             index=pd.Index([0, 3, 1, 4], name='chooser_id')))
 
 
@@ -462,7 +460,7 @@ def test_mnl_dcm_segmented(seed, grouped_choosers, alternatives):
     pdt.assert_series_equal(
         choices,
         pd.Series(
-            ['c', 'b', 'i', 'b', 'j'],
+            ['c', 'a', 'b', 'a', 'j'],
             index=pd.Index([0, 2, 3, 1, 4], name='chooser_id')))
 
     # check that we don't get the same alt twice if they are removed
@@ -474,7 +472,7 @@ def test_mnl_dcm_segmented(seed, grouped_choosers, alternatives):
     pdt.assert_series_equal(
         choices,
         pd.Series(
-            ['c', 'b', 'i', 'a', 'j'],
+            ['c', 'a', 'b', 'd', 'j'],
             index=pd.Index([0, 2, 3, 1, 4], name='chooser_id')))
 
 

--- a/urbansim/urbanchoice/interaction.py
+++ b/urbansim/urbanchoice/interaction.py
@@ -54,6 +54,10 @@ def mnl_interaction_dataset(choosers, alternatives, SAMPLE_SIZE,
     # because a) why not? and b) testing.
     alts_idx = np.arange(len(alternatives))
     if SAMPLE_SIZE < numalts:
+        # TODO: Use stdlib random.sample to individually choose
+        # alternatives for each chooser (to avoid repeatedly choosing the
+        # same alternative).
+        # random.sample is much faster than np.random.choice.
         sample = np.random.choice(alts_idx, SAMPLE_SIZE * numchoosers)
         if chosenalts is not None:
             # replace the first row for each chooser with

--- a/urbansim/urbanchoice/interaction.py
+++ b/urbansim/urbanchoice/interaction.py
@@ -54,10 +54,7 @@ def mnl_interaction_dataset(choosers, alternatives, SAMPLE_SIZE,
     # because a) why not? and b) testing.
     alts_idx = np.arange(len(alternatives))
     if SAMPLE_SIZE < numalts:
-        sample = np.concatenate(tuple(
-            np.random.choice(alts_idx, SAMPLE_SIZE, replace=False)
-            for _ in range(numchoosers)))
-
+        sample = np.random.choice(alts_idx, SAMPLE_SIZE * numchoosers)
         if chosenalts is not None:
             # replace the first row for each chooser with
             # the currently chosen alternative.


### PR DESCRIPTION
This addresses https://github.com/UDST/bayarea_urbansim/issues/65 by reverting https://github.com/UDST/urbansim/commit/d17a5ced1aca84e9e0fce0249921255804d51a52. That change was made to ensure that choosers weren't being given the opportunity to choose the same alternative multiple times, but performance is very bad with `np.random.choice` being called many tens of thousands of times. In most UrbanSim LCM applications the pool of available alternatives is much larger than the alternative sample size so we don't worry too much about repeated sampling, but it could be a problem in other contexts.

One possible solution allowing us to do individual sampling would be to use the Python standard library's `random.sample`, which is much, much faster than `np.random.choice`. The downside of that approach is that it introduces a second source of randomness that must be controlled to get repeatable runs (as in unit testing).