### PR TITLE
fixed a problem with deck parking in the developer

### DIFF
--- a/urbansim/developer/developer.py
+++ b/urbansim/developer/developer.py
@@ -190,9 +190,12 @@ class Developer(object):
             print "WARNING THERE WERE NOT ENOUGH PROFITABLE UNITS TO " \
                   "MATCH DEMAND"
 
+        df['max_profit_per_size'] = df.max_profit / df.parcel_size
+
         choices = np.random.choice(df.index.values, size=len(df.index),
                                    replace=False,
-                                   p=(df.max_profit.values / df.max_profit.sum()))
+                                   p=(df.max_profit_per_size.values /
+                                      df.max_profit_per_size.sum()))
         net_units = df.net_units.loc[choices]
         tot_units = net_units.values.cumsum()
         ind = int(np.searchsorted(tot_units, target_units, side="left"))

--- a/urbansim/developer/sqftproforma.py
+++ b/urbansim/developer/sqftproforma.py
@@ -628,8 +628,6 @@ class SqFtProForma(object):
         outdf["residential_sqft"] = outdf.building_sqft * c.building_efficiency * resratio
         outdf["non_residential_sqft"] = outdf.building_sqft * c.building_efficiency * nonresratio
 
-        outdf.to_csv('debug_%s_%s.csv' % (form, parking_config))
-
         if only_built:
             outdf = outdf.query('max_profit > 0').copy()
 

--- a/urbansim/developer/sqftproforma.py
+++ b/urbansim/developer/sqftproforma.py
@@ -596,13 +596,15 @@ class SqFtProForma(object):
 
         fars = np.repeat(cost_sqft_index_col, len(df.index), axis=1)
 
-        # zero out fars not allowed by zoning
+        # turn fars into nans which are not allowed by zoning
+        # (so we can fillna with one of the other zoning constraints)
         fars[fars > df.min_max_fars.values + .01] = np.nan
 
         # same thing for heights
         heights = np.repeat(heights, len(df.index), axis=1)
 
-        # zero out heights not allowed by zoning
+        # turn heights into nans which are not allowed by zoning
+        # (so we can fillna with one of the other zoning constraints)
         fars[heights > df.max_height.values + .01] = np.nan
 
         # parcel sizes * possible fars

--- a/urbansim/developer/sqftproforma.py
+++ b/urbansim/developer/sqftproforma.py
@@ -181,7 +181,7 @@ class SqFtProFormaConfig(object):
             'underground': 110
         }
 
-        self.height_per_story = 10.0
+        self.height_per_story = 12.0
         self.max_retail_height = 2.0
         self.max_industrial_height = 2.0
 
@@ -375,46 +375,31 @@ class SqFtProForma(object):
                     stories = building_bulk / \
                         (c.tiled_parcel_sizes - parkingstalls *
                          c.parking_sqft_d[parking_config])
-                    df['park_sqft'] = parkingstalls * \
-                        c.parking_sqft_d[parking_config]
+                    df['park_sqft'] = 0
                     # not all fars support surface parking
                     stories[np.where(stories < 0.0)] = np.nan
 
-                df['total_sqft'] = df.building_sqft + df.park_sqft
+                df['total_built_sqft'] = df.building_sqft + df.park_sqft
+                df['parking_sqft_ratio'] = df.park_sqft / df.total_built_sqft
                 stories /= c.parcel_coverage
                 df['stories'] = np.ceil(stories)
+                df['height'] = df.stories * c.height_per_story
                 df['build_cost_sqft'] = self._building_cost(uses_distrib, stories)
 
                 df['build_cost'] = df.build_cost_sqft * df.building_sqft
                 df['park_cost'] = parking_cost
                 df['cost'] = df.build_cost + df.park_cost
 
-                df['ave_cost_sqft'] = (df.cost / df.total_sqft) * c.profit_factor
+                df['ave_cost_sqft'] = (df.cost / df.total_built_sqft) * c.profit_factor
 
                 if name == 'retail':
                     df['ave_cost_sqft'][c.fars > c.max_retail_height] = np.nan
                 if name == 'industrial':
                     df['ave_cost_sqft'][c.fars > c.max_industrial_height] = np.nan
+
                 df_d[(name, parking_config)] = df
 
-        # from here on out we need the min rent for a form and a far
-        min_ave_cost_sqft_d = {}
-        bignum = 999999
-
-        for name in keys:
-            min_ave_cost_sqft = None
-            for parking_config in c.parking_configs:
-                ave_cost_sqft = df_d[(name, parking_config)][
-                    'ave_cost_sqft'].fillna(bignum)
-                min_ave_cost_sqft = ave_cost_sqft if min_ave_cost_sqft is None \
-                    else np.minimum(min_ave_cost_sqft, ave_cost_sqft)
-
-            min_ave_cost_sqft = min_ave_cost_sqft.replace(bignum, np.nan)
-            # this is the minimum cost per sqft for this form and far
-            min_ave_cost_sqft_d[name] = min_ave_cost_sqft
-
         self.dev_d = df_d
-        self.min_ave_cost_d = min_ave_cost_sqft_d
 
     def get_debug_info(self, form, parking_config):
         """
@@ -438,26 +423,6 @@ class SqFtProForma(object):
 
         """
         return self.dev_d[(form, parking_config)]
-
-    def get_ave_cost_sqft(self, form):
-        """
-        Get the average cost per sqft for the pro forma for a given form
-
-        Parameters
-        ----------
-        form : string
-            Get a series representing the average cost per sqft for each form in
-            the config
-
-        Returns
-        -------
-        cost : series
-            A series where the index is the far and the values are the average
-            cost per sqft at which the building is "break even" given the
-            configuration parameters that were passed at run time.
-
-        """
-        return self.min_ave_cost_d[form]
 
     def lookup(self, form, df, only_built=True, pass_through=None):
         """
@@ -536,14 +501,43 @@ class SqFtProForma(object):
             and max_height from the input dataframe).
 
         """
+        c = self.config
+        d = {}
+        profit_d = {}
+        for parking_config in c.parking_configs:
+            # this function gives the max profit development for the given
+            # parking config need to iterate over parking configs to pick the
+            # max profit config
+            outdf = self._lookup_parking_cfg(form, parking_config, df, only_built,
+                                             pass_through)
+            d[parking_config] = outdf
+            profit_d[parking_config] = outdf["max_profit"]
+
+        # get the max_profit idx
+        max_profit_ind = pd.DataFrame(profit_d).idxmax(axis=1)
+        # make a new df of all the attribuets from the max profit df
+        rows = {index: d[parking_config].loc[index] for index, parking_config
+                in max_profit_ind.iteritems()}
+        df = pd.DataFrame.from_dict(rows, orient="index")
+        df["parking_config"] = max_profit_ind
+
+        return df
+
+    def _lookup_parking_cfg(self, form, parking_config, df, only_built=True,
+                            pass_through=None):
+
+        dev_info = self.dev_d[(form, parking_config)]
+
+        cost_sqft_col = np.reshape(dev_info.ave_cost_sqft.values, (-1, 1))
+        cost_sqft_index_col = np.reshape(dev_info.index.values, (-1, 1))
+
+        parking_sqft_ratio = np.reshape(dev_info.parking_sqft_ratio.values, (-1, 1))
+        heights = np.reshape(dev_info.height.values, (-1, 1))
+
         # don't really mean to edit the df that's passed in
         df = df.copy()
 
         c = self.config
-
-        cost_sqft = self.get_ave_cost_sqft(form)
-        cost_sqft_col = np.reshape(cost_sqft.values, (-1, 1))
-        cost_sqft_index_col = np.reshape(cost_sqft.index.values, (-1, 1))
 
         # weighted rent for this form
         df['weighted_rent'] = np.dot(df[c.uses], c.forms[form])
@@ -581,11 +575,16 @@ class SqFtProForma(object):
         if only_built:
             df = df.query('min_max_fars > 0 and parcel_size > 0')
 
-        # all possible fars on all parcels
         fars = np.repeat(cost_sqft_index_col, len(df.index), axis=1)
 
         # zero out fars not allowed by zoning
         fars[fars > df.min_max_fars.values + .01] = np.nan
+
+        # same thing for heights
+        heights = np.repeat(heights, len(df.index), axis=1)
+
+        # zero out heights not allowed by zoning
+        fars[heights > df.max_height.values + .01] = np.nan
 
         # parcel sizes * possible fars
         building_bulks = fars * df.parcel_size.values
@@ -597,8 +596,8 @@ class SqFtProForma(object):
         total_costs = building_costs + df.land_cost.values
 
         # rent to make for the new building
-        building_revenue = building_bulks * c.building_efficiency *\
-            df.weighted_rent.values / c.cap_rate
+        building_revenue = building_bulks * (1-parking_sqft_ratio) * \
+            c.building_efficiency * df.weighted_rent.values / c.cap_rate
 
         # profit for each form
         profit = building_revenue - total_costs
@@ -613,6 +612,8 @@ class SqFtProForma(object):
         outdf = pd.DataFrame({
             'building_sqft': twod_get(maxprofitind, building_bulks),
             'building_cost': twod_get(maxprofitind, building_costs),
+            'parking_ratio': parking_sqft_ratio[maxprofitind].flatten(),
+            'stories': twod_get(maxprofitind, heights) / c.height_per_story,
             'total_cost': twod_get(maxprofitind, total_costs),
             'building_revenue': twod_get(maxprofitind, building_revenue),
             'max_profit_far': twod_get(maxprofitind, fars),
@@ -622,14 +623,15 @@ class SqFtProForma(object):
         if pass_through:
             outdf[pass_through] = df[pass_through]
 
-        if only_built:
-            outdf = outdf.query('max_profit > 0').copy()
-
         resratio = c.res_ratios[form]
         nonresratio = 1.0 - resratio
         outdf["residential_sqft"] = outdf.building_sqft * c.building_efficiency * resratio
-        outdf["non_residential_sqft"] = outdf.building_sqft * nonresratio
-        outdf["stories"] = outdf["max_profit_far"] / c.parcel_coverage
+        outdf["non_residential_sqft"] = outdf.building_sqft * c.building_efficiency * nonresratio
+
+        outdf.to_csv('debug_%s_%s.csv' % (form, parking_config))
+
+        if only_built:
+            outdf = outdf.query('max_profit > 0').copy()
 
         return outdf
 

--- a/urbansim/developer/sqftproforma.py
+++ b/urbansim/developer/sqftproforma.py
@@ -424,6 +424,25 @@ class SqFtProForma(object):
         """
         return self.dev_d[(form, parking_config)]
 
+    def get_ave_cost_sqft(self, form, parking_config):
+        """
+        Get the average cost per sqft for the pro forma for a given form
+        Parameters
+        ----------
+        form : string
+            Get a series representing the average cost per sqft for each form in
+            the config
+        parking_config : string
+            The parking configuration to get debug info for
+        Returns
+        -------
+        cost : series
+            A series where the index is the far and the values are the average
+            cost per sqft at which the building is "break even" given the
+            configuration parameters that were passed at run time.
+        """
+        return self.dev_d[(form, parking_config)].ave_cost_sqft
+
     def lookup(self, form, df, only_built=True, pass_through=None):
         """
         This function does the developer model lookups for all the actual input data.
@@ -652,7 +671,7 @@ class SqFtProForma(object):
             logger.debug(df_d[key])
         for form in self.config.forms:
             logger.debug("\n" + str(key) + "\n")
-            logger.debug(self.get_ave_cost_sqft(form))
+            logger.debug(self.get_ave_cost_sqft(form, "surface"))
 
         keys = c.forms.keys()
         keys.sort()


### PR DESCRIPTION
most of this commit is to make sure we account for the amount of a building that is parking and the amount that is not when crediting rents for the building.

the old structure of the pro forma was to maxmize the parking format (surface, deck, underground) in the precomputation part of the pro forma.  now this is put off until actual rents and costs are known.  this allows more flexibility in how the comutation is done.

in this case it actually removed a bug where we were giving too much rent for space that is actually only devoting to parking, which made itself known in the simulations as redeveloping sururban office developments that had surface parking and turning them into dense deck parking office developments because although the cost of the parking was taken into account, it was also given an offsetting rent because it was being subtracted from the utilized space.

this ended up being a very pervasive change which made me think that, more than ever, the developer model needs to be written in some way that is not vectorized.  presumably cython or just C or possibly directly in Excel and then stored as a lookup table.