### PR TITLE
use `pd.Int64Index()`

### DIFF
--- a/urbansim/models/tests/test_transition.py
+++ b/urbansim/models/tests/test_transition.py
@@ -83,6 +83,10 @@ def assert_empty_index(index):
     pdt.assert_index_equal(index, pd.Index([]))
 
 
+def assert_empty_int64index(index):
+    pdt.assert_index_equal(index, pd.Int64Index([]))
+
+
 def assert_for_add(new, added):
     assert len(new) == 7
     pdt.assert_index_equal(added, pd.Index([105, 106]))
@@ -324,7 +328,7 @@ def test_tgrtransition_with_accounting(random_df):
     a_target = orig_total + a_change
     assert a_change * -1 == a_removed_rows['some_count'].sum()
     assert a_target == new[new['segment'] == 'a']['some_count'].sum()
-    assert_empty_index(a_added_rows.index)
+    assert_empty_int64index(a_added_rows.index)
 
     # test a growing segment
     b_added_rows = added_rows[added_rows['segment'] == 'b']
@@ -333,14 +337,14 @@ def test_tgrtransition_with_accounting(random_df):
     b_target = orig_total + b_change
     assert b_change == b_added_rows['some_count'].sum()
     assert b_target == new[new['segment'] == 'b']['some_count'].sum()
-    assert_empty_index(b_removed_rows.index)
+    assert_empty_int64index(b_removed_rows.index)
 
     # test a no change segment
     c_added_rows = added_rows[added_rows['segment'] == 'c']
     c_removed_rows = removed_rows[removed_rows['segment'] == 'c']
     assert orig_total == new[new['segment'] == 'c']['some_count'].sum()
-    assert_empty_index(c_added_rows.index)
-    assert_empty_index(c_removed_rows.index)
+    assert_empty_int64index(c_added_rows.index)
+    assert_empty_int64index(c_removed_rows.index)
 
 
 def test_tgrtransition_remove_all(basic_df, growth_rates, year, rates_col):

--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -100,7 +100,9 @@ def remove_rows(data, nrows, accounting_column=None):
     remove_index = remove_rows.index
 
     logger.debug('finish: removed {} rows in transition model'.format(nrows))
-    return data.loc[data.index.diff(remove_index)], remove_index
+    data = data.loc[data.index.diff(remove_index)]
+    data = pd.DataFrame(data, index=pd.Int64Index(data.index))
+    return data, remove_index
 
 
 def add_or_remove_rows(data, nrows, starting_index=None, accounting_column=None):


### PR DESCRIPTION
* return `pd.DataFrame` with `pd.Int64Index()` index in `remove_rows()`
* add `assert_empty_int64index()` to use with `test_tgrtransition_with_accounting()`

I tried changing as little code as possible.

Note that the failed build is due to changes in pandas (possibly 0.18 (or >=0.17.1)), as commented [here](https://github.com/UDST/urbansim/commit/058a930f31cd9c9c4d16c1875578f3c66086cc3f#commitcomment-16666541).

--

Alternatively, for the `test_*remove*all()` tests at least, the `check_index_type` option in `pdt.assert_frame_equal()` can be set to `False`. This isn't guaranteed to fix everything.