### PR TITLE
Iss dtype warning

### DIFF
--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -1822,7 +1822,7 @@ class SegmentedMNLDiscreteChoiceModel(DiscreteChoiceModel):
                 (len(alternatives), len(choosers)))
             idxes = np.random.choice(
                 alternatives.index,
-                size=np.floor(len(choosers) * alternative_ratio),
+                size=int(np.floor(len(choosers) * alternative_ratio)),
                 replace=False)
             alternatives = alternatives.loc[idxes]
             logger.info(

--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -100,7 +100,7 @@ def remove_rows(data, nrows, accounting_column=None):
     remove_index = remove_rows.index
 
     logger.debug('finish: removed {} rows in transition model'.format(nrows))
-    return data.loc[data.index.diff(remove_index)], remove_index
+    return data.loc[data.index.difference(remove_index)], remove_index
 
 
 def add_or_remove_rows(data, nrows, starting_index=None, accounting_column=None):

--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -309,11 +309,11 @@ class TabularGrowthRateTransition(object):
                 continue
 
             if self.accounting_column is None:
-                nrows = self._calc_nrows(len(subset), row[self._config_column])
+                nrows = self._calc_nrows(len(subset), int(row[self._config_column]))
             else:
                 nrows = self._calc_nrows(
                     subset[self.accounting_column].sum(),
-                    row[self._config_column])
+                    int(row[self._config_column]))
 
             updated, added, copied, removed = \
                 add_or_remove_rows(subset, nrows, starting_index, self.accounting_column)


### PR DESCRIPTION
Add explicit casts to int to enforce contract between method signature and data types. Helps avoid deprecation warnings in Numpy random chooser methods.

transitions.py: Considered changing loop from iterrows to itertuples to maintain dtype as integer, but that caused a series of downstream conflicts as the iterrows returns a series which is immediately used and itertuples returns a tuple with maintained dtypes. The tuple loses its proper dtypes once it is converted into a series for future operations.
