### PR TITLE
pass yaml str from memory to predict_from_cfg

### DIFF
--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -815,13 +815,14 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
         lcm : MNLDiscreteChoiceModel which was used to predict
         """
         logger.debug('start: predict from configuration {}'.format(cfgname))
-        try:
-            if cfgname:
-                lcm = cls.from_yaml(str_or_buffer=cfgname)
-            else:
-                lcm = cls.from_yaml(yaml_str=cfg)
-        except:
-            logger.debug('no lcm config loaded')
+        if cfgname:
+            lcm = cls.from_yaml(str_or_buffer=cfgname)
+        elif cfg: 
+            lcm = cls.from_yaml(yaml_str=cfg)
+        else:
+            msg = 'predict_from_cfg requires a configuration via the cfgname or cfg arguments'
+            logger.error(msg)
+            raise ValueError(msg)
 
         if len(alternatives) > len(choosers) * alternative_ratio:
             logger.info(
@@ -1825,14 +1826,14 @@ class SegmentedMNLDiscreteChoiceModel(DiscreteChoiceModel):
         lcm : SegmentedMNLDiscreteChoiceModel which was used to predict
         """
         logger.debug('start: predict from configuration {}'.format(cfgname))
-        try:
-            if cfgname:
-                lcm = cls.from_yaml(str_or_buffer=cfgname)
-                print("reading config from file")
-            else:
-                lcm = cls.from_yaml(yaml_str=cfg)
-        except:
-            logger.debug('no lcm config loaded')
+        if cfgname:
+            lcm = cls.from_yaml(str_or_buffer=cfgname)
+        elif cfg: 
+            lcm = cls.from_yaml(yaml_str=cfg)
+        else:
+            msg = 'predict_from_cfg requires a configuration via the cfgname or cfg arguments'
+            logger.error(msg)
+            raise ValueError(msg)
 
         if len(alternatives) > len(choosers) * alternative_ratio:
             logger.info(

--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -817,7 +817,7 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
         logger.debug('start: predict from configuration {}'.format(cfgname))
         if cfgname:
             lcm = cls.from_yaml(str_or_buffer=cfgname)
-        elif cfg: 
+        elif cfg:
             lcm = cls.from_yaml(yaml_str=cfg)
         else:
             msg = 'predict_from_cfg requires a configuration via the cfgname or cfg arguments'
@@ -1828,7 +1828,7 @@ class SegmentedMNLDiscreteChoiceModel(DiscreteChoiceModel):
         logger.debug('start: predict from configuration {}'.format(cfgname))
         if cfgname:
             lcm = cls.from_yaml(str_or_buffer=cfgname)
-        elif cfg: 
+        elif cfg:
             lcm = cls.from_yaml(yaml_str=cfg)
         else:
             msg = 'predict_from_cfg requires a configuration via the cfgname or cfg arguments'

--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -781,7 +781,7 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
         return lcm
 
     @classmethod
-    def predict_from_cfg(cls, choosers, alternatives, cfgname,
+    def predict_from_cfg(cls, choosers, alternatives, cfgname=None, cfg=None,
                          alternative_ratio=2.0, debug=False):
         """
         Simulate choices for the specified choosers
@@ -796,6 +796,9 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
         cfgname : string
             The name of the yaml config file from which to read the discrete
             choice model.
+        cfg: string
+            an ordered yaml string of the model discrete choice model configuration.
+            Used to read config from memory in lieu of loading cfgname from disk.
         alternative_ratio : float, optional
             Above the ratio of alternatives to choosers (default of 2.0),
             the alternatives will be sampled to meet this ratio
@@ -812,7 +815,13 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
         lcm : MNLDiscreteChoiceModel which was used to predict
         """
         logger.debug('start: predict from configuration {}'.format(cfgname))
-        lcm = cls.from_yaml(str_or_buffer=cfgname)
+        try:
+            if cfgname:
+                lcm = cls.from_yaml(str_or_buffer=cfgname)
+            else:
+                lcm = cls.from_yaml(yaml_str=cfg)
+        except:
+            logger.debug('no lcm config loaded')
 
         if len(alternatives) > len(choosers) * alternative_ratio:
             logger.info(
@@ -1784,7 +1793,7 @@ class SegmentedMNLDiscreteChoiceModel(DiscreteChoiceModel):
         return lcm
 
     @classmethod
-    def predict_from_cfg(cls, choosers, alternatives, cfgname,
+    def predict_from_cfg(cls, choosers, alternatives, cfgname=None, cfg=None,
                          alternative_ratio=2.0, debug=False):
         """
         Simulate the discrete choices for the specified choosers
@@ -1799,6 +1808,9 @@ class SegmentedMNLDiscreteChoiceModel(DiscreteChoiceModel):
         cfgname : string
             The name of the yaml config file from which to read the discrete
             choice model.
+        cfg: string
+            an ordered yaml string of the model discrete choice model configuration.
+            Used to read config from memory in lieu of loading cfgname from disk.
         alternative_ratio : float
             Above the ratio of alternatives to choosers (default of 2.0),
             the alternatives will be sampled to meet this ratio
@@ -1813,7 +1825,14 @@ class SegmentedMNLDiscreteChoiceModel(DiscreteChoiceModel):
         lcm : SegmentedMNLDiscreteChoiceModel which was used to predict
         """
         logger.debug('start: predict from configuration {}'.format(cfgname))
-        lcm = cls.from_yaml(str_or_buffer=cfgname)
+        try:
+            if cfgname:
+                lcm = cls.from_yaml(str_or_buffer=cfgname)
+                print("reading config from file")
+            else:
+                lcm = cls.from_yaml(yaml_str=cfg)
+        except:
+            logger.debug('no lcm config loaded')
 
         if len(alternatives) > len(choosers) * alternative_ratio:
             logger.info(


### PR DESCRIPTION
Currently, in the MNLDiscreteChoiceModel and SegmentedMNLDiscreteChoiceModel classes, the predict_from_cfg helper function defaults to using from_yaml by passing a file path string. However, from_yaml includes a yaml_str option that allows for passing the config in from memory as a yaml string. This change allows for passing a yaml config string from memory into predict_from_cfg, which is useful in the case that configurations need to be edited within a model and an lcm run based on those edited configs (and where you don't really want to save out the yaml file).