### PR TITLE
20161109 bugfix in models.transition.remove_rows

### DIFF
--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -93,8 +93,10 @@ def remove_rows(data, nrows, accounting_column=None):
     nrows = abs(nrows)  # in case a negative number came in
     if nrows == 0:
         return data, _empty_index()
-    elif nrows > len(data):
+    elif (nrows > len(data)) and (accounting_column is None):
         raise ValueError('Number of rows to remove exceeds number of rows in table.')
+    elif (nrows > data[accounting_column].sum()):
+        raise ValueError('Cumulated amount to remove exceeds accounting total in table.')
 
     remove_rows = sample_rows(nrows, data, accounting_column=accounting_column, replace=False)
     remove_index = remove_rows.index

--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -93,9 +93,9 @@ def remove_rows(data, nrows, accounting_column=None):
     nrows = abs(nrows)  # in case a negative number came in
     if nrows == 0:
         return data, _empty_index()
-    elif (nrows > len(data)) and (accounting_column is None):
+    elif (accounting_column is None) and (nrows > len(data)):
         raise ValueError('Number of rows to remove exceeds number of rows in table.')
-    elif (nrows > data[accounting_column].sum()):
+    elif (accounting_column is not None) and (nrows > data[accounting_column].sum()):
         raise ValueError('Cumulated amount to remove exceeds accounting total in table.')
 
     remove_rows = sample_rows(nrows, data, accounting_column=accounting_column, replace=False)


### PR DESCRIPTION
Correction for the following problem:

error handling is too strict:
whith accounting_column != None, the function won't allow removing an amount  len(data) < nrows < data[accounting_columns].sum(), even if this is possible.