### PR TITLE
Fix sample rows no replace

### DIFF
--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -210,7 +210,9 @@ def sample_rows(total, data, replace=True, accounting_column=None,
     if accounting_column is None:
         if replace is False and total > len(data.index.values):
             raise ValueError('Control total exceeds the available samples')
-        rows = data.loc[np.random.choice(data.index.values, total, replace=replace)].copy()
+        p = get_probs(prob_column)
+        rows = data.loc[np.random.choice(
+            data.index.values, total, replace=replace, p=p)].copy()
         matched = True
 
     # sample with accounting

--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -3,7 +3,207 @@ import numpy as np
 import pandas as pd
 
 
-def sample_rows(total, data, replace=True, accounting_column=None, max_iterations=50):
+def get_probs(data, prob_column=None):
+    """
+    Checks for presence of a probability column and returns the result
+    as a numpy array. If the probabilities are weights (i.e. they don't)
+    sum to 1, then this will be recalculated.
+
+    Parameters
+    ----------
+    data: pandas.DataFrame
+        Table to sample from.
+    prob_column: string, optional, default None
+        Name of the column in the data to provide probabilities or weights.
+
+    Returns
+    -------
+    numpy.array
+
+    """
+    if prob_column is None:
+        p = None
+    else:
+        p = data[prob_column].values
+        if round(p.sum(), 0) != 1:
+            p = p / (1.0 * p.sum())
+    return p
+
+
+def accounting_sample_replace(total, data, accounting_column,
+                              prob_column=None, exact=True, max_iterations=50):
+    """
+    Sample rows with accounting with replacement.
+
+    Parameters
+    ----------
+    total : int
+        The control total the sampled rows will attempt to match.
+    data: pandas.DataFrame
+        Table to sample from.
+    accounting_column: string, optional
+        Name of column with accounting totals/quantities to apply towards the control.
+        If not provided then row counts will be used for accounting.
+    prob_column: string, optional, default None
+        Name of the column in the data to provide probabilities or weights.
+    exact: bool, optional, default True
+        If True, will attempt to match the total exactly. Otherwise it will be an
+        approximation.
+    max_iterations: int, optional, default 50
+        When using an accounting attribute, the maximum number of sampling iterations
+        that will be applied.
+
+    Returns
+    -------
+    sample_rows : pandas.DataFrame
+        Table containing the sample.
+
+    """
+
+    # check for probabilities
+    p = get_probs(data, prob_column)
+
+    # determine avg number of accounting items per sample (e.g. persons per household)
+    per_sample = data[accounting_column].sum() / (1.0 * len(data.index.values))
+
+    curr_total = 0
+    remaining = total
+    sample_rows = pd.DataFrame()
+    closest = None
+    closest_remain = total
+
+    for i in range(0, max_iterations):
+
+        # stop if we've hit the control
+        if remaining == 0:
+            break
+
+        # stop after the 1st iteration if we're approximating w/out probs
+        if (not exact) and i == 1 and p is None:
+            break
+
+        # stop afer the 2nd iteration if we're approximating w/ probs
+        if (not exact) and i == 2 and p is not None:
+            break
+
+        # if sampling with probabilities, re-caclc the # of items per sample
+        # after the initial sample, this way the sample size reflects the probabilities
+        if p is not None and i == 1:
+            per_sample = sample_rows[accounting_column].sum / (1.0 * len(sample_rows))
+
+        # update the sample
+        num_samples = int(math.ceil(math.fabs(remaining) / per_sample))
+
+        if remaining > 0:
+            # we're short, add to the sample
+            curr_ids = np.random.choice(data.index.values, num_samples, p=p)
+            sample_rows = pd.concat([sample_rows, data.loc[curr_ids]])
+        else:
+            # we've overshot, remove from existing samples (FIFO)
+            sample_rows = sample_rows.iloc[num_samples:].copy()
+
+        # update the total and check for the closest result
+        curr_total = sample_rows[accounting_column].sum()
+        remaining = total - curr_total
+
+        if abs(remaining) < closest_remain:
+            closest_remain = abs(remaining)
+            closest = sample_rows
+
+    return closest
+
+
+def accounting_sample_no_replace(total, data, accounting_column,
+                                 prob_column=None, exact=True, max_iterations=50):
+    """
+    Samples rows with accounting without replacement.
+
+    Parameters
+    ----------
+    total : int
+        The control total the sampled rows will attempt to match.
+    data: pandas.DataFrame
+        Table to sample from.
+    accounting_column: string
+        Name of column with accounting totals/quantities to apply towards the control.
+    prob_column: string, optional, default None
+        Name of the column in the data to provide probabilities or weights.
+    exact: bool, optional, default True
+        If True, will attempt to match the total exactly. Otherwise it will be an
+        approximation.
+    max_iterations: int, optional, default 50
+        When using an accounting attribute, the maximum number of sampling iterations
+        that will be applied.
+
+    Returns
+    -------
+    sample_rows : pandas.DataFrame
+        Table containing the sample.
+
+    """
+
+    # make sure this is even feasible
+    if total > data[accounting_column].sum():
+        raise ValueError('Control total exceeds the available samples')
+
+    # check for probabilities
+    p = get_probs(data, prob_column)
+
+    closest = None
+    closest_shortage = total
+
+    for i in range(0, max_iterations):
+
+        print i
+
+        # shuffle the rows
+        if p is None:
+            # random shuffle
+            shuff_idx = np.random.permutation(data.index.values)
+        else:
+            # weighted shuffle
+            shuff_idx = np.random.choice(data.index.values, len(data), replace=False, p=p)
+
+        # get the initial sample
+        shuffle = data.loc[shuff_idx]
+        csum = np.cumsum(shuffle[accounting_column].values)
+        pos = np.searchsorted(csum, total, 'right')
+        sample = shuffle.iloc[:pos]
+
+        # if we're just approximating we're done
+        if not exact:
+            return sample.copy()
+
+        # refine the sample
+        sample_idx = sample.index.values
+        sample_total = sample[accounting_column].sum()
+        shortage = total - sample_total
+
+        for idx, row in shuffle.iloc[pos:].iterrows():
+            if shortage == 0:
+                # we've matached
+                break
+
+            # add the current element if it doesnt exceed the total
+            cnt = row[accounting_column]
+            if cnt <= shortage:
+                sample_idx = np.append(sample_idx, idx)
+                shortage -= cnt
+
+        # we've looped through all the elements, compare with other iterations
+        if shortage == 0:
+            closest = shuffle.loc[sample_idx].copy()
+            break
+        else:
+            if abs(shortage) < closest_shortage:
+                closest = shuffle.loc[sample_idx].copy()
+                closest_shortage = shortage
+
+    return closest
+
+
+def sample_rows(total, data, replace=True, accounting_column=None,
+                max_iterations=50, prob_column=None, exact=True):
     """
     Samples and returns rows from a data frame while matching a desired control total. The total may
     represent a simple row count or may attempt to match a sum/quantity from an accounting column.
@@ -35,52 +235,9 @@ def sample_rows(total, data, replace=True, accounting_column=None, max_iteration
             raise ValueError('Control total exceeds the available samples')
         return data.loc[np.random.choice(data.index.values, total, replace=replace)].copy()
 
-    # make sure this is even feasible
-    if replace is False and total > data[accounting_column].sum():
-        raise ValueError('Control total exceeds the available samples')
-
-    # determine avg number of accounting items per sample (e.g. persons per household)
-    per_sample = data[accounting_column].sum() / (1.0 * len(data.index.values))
-
-    # do the initial sample
-    num_samples = int(math.ceil(total / per_sample))
     if replace:
-        sample_idx = data.index.values
-        sample_ids = np.random.choice(sample_idx, num_samples)
+        func = accounting_sample_replace
     else:
-        sample_idx = np.random.permutation(data.index.values)
-        sample_ids = sample_idx[0:num_samples]
-        sample_pos = num_samples
+        func = accounting_sample_no_replace
 
-    sample_rows = data.loc[sample_ids].copy()
-    curr_total = sample_rows[accounting_column].sum()
-
-    # iteratively refine the sample until we match the accounting total
-    for i in range(0, max_iterations):
-
-        # keep going if we haven't hit the control
-        remaining = total - curr_total
-        if remaining == 0:
-            break
-        num_samples = int(math.ceil(math.fabs(remaining) / per_sample))
-
-        if remaining > 0:
-            # we're short, keep sampling
-            if replace:
-                curr_ids = np.random.choice(sample_idx, num_samples)
-            else:
-                curr_ids = sample_idx[sample_pos:sample_pos + num_samples]
-                sample_pos += num_samples
-
-            curr_rows = data.loc[curr_ids].copy()
-            sample_rows = pd.concat([sample_rows, curr_rows])
-            curr_total += curr_rows[accounting_column].sum()
-        else:
-            # we've overshot, remove from existing samples (FIFO)
-            curr_rows = sample_rows[:num_samples]
-            sample_rows = sample_rows[num_samples:]
-            curr_total -= curr_rows[accounting_column].sum()
-            if not replace:
-                np.append(sample_idx, curr_rows.index.values)
-
-    return sample_rows.copy()
+    return func(total, data, accounting_column, prob_column, exact, max_iterations)

--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -192,6 +192,9 @@ def sample_rows(total, data, replace=True, accounting_column=None,
     max_iterations: int, optional, default 50
         When using an accounting attribute, the maximum number of sampling iterations
         that will be applied. Only applicable when sampling with replacement.
+    prob_column: string, optional, default None
+        If provided, name of the column in the data frame to provide probabilities
+        or weights. If not provided, the sampling is random.
     return_status: bool, optional, default True
         If True, will also return a bool indicating if the total was matched exactly.
 

--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -206,6 +206,9 @@ def sample_rows(total, data, replace=True, accounting_column=None,
         If return_status is True, returns True if total is matched exactly.
 
     """
+    if not data.index.is_unique:
+        raise ValueError('Data must have a unique index')
+
     # simplest case, just return n random rows
     if accounting_column is None:
         if replace is False and total > len(data.index.values):

--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -56,8 +56,8 @@ def accounting_sample_replace(total, data, accounting_column, prob_column=None, 
         Table containing the sample.
     matched: bool
         Indicates if the total was matched exactly.
-    """
 
+    """
     # check for probabilities
     p = get_probs(data, prob_column)
 
@@ -119,9 +119,6 @@ def accounting_sample_no_replace(total, data, accounting_column, prob_column=Non
         Name of column with accounting totals/quantities to apply towards the control.
     prob_column: string, optional, default None
         Name of the column in the data to provide probabilities or weights.
-    exact: bool, optional, default True
-        If True, will attempt to match the total exactly. Otherwise it will be an
-        approximation.
 
     Returns
     -------
@@ -131,7 +128,6 @@ def accounting_sample_no_replace(total, data, accounting_column, prob_column=Non
         Indicates if the total was matched exactly.
 
     """
-
     # make sure this is even feasible
     if total > data[accounting_column].sum():
         raise ValueError('Control total exceeds the available samples')
@@ -203,8 +199,10 @@ def sample_rows(total, data, replace=True, accounting_column=None,
     -------
     sample_rows : pandas.DataFrame
         Table containing the sample.
-    """
+    matched: bool
+        If return_status is True, returns True if total is matched exactly.
 
+    """
     # simplest case, just return n random rows
     if accounting_column is None:
         if replace is False and total > len(data.index.values):

--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -42,9 +42,8 @@ def accounting_sample_replace(total, data, accounting_column, prob_column=None, 
         The control total the sampled rows will attempt to match.
     data: pandas.DataFrame
         Table to sample from.
-    accounting_column: string, optional
+    accounting_column: string
         Name of column with accounting totals/quantities to apply towards the control.
-        If not provided then row counts will be used for accounting.
     prob_column: string, optional, default None
         Name of the column in the data to provide probabilities or weights.
     max_iterations: int, optional, default 50
@@ -89,7 +88,6 @@ def accounting_sample_replace(total, data, accounting_column, prob_column=None, 
 
         if remaining > 0:
             # we're short, add to the sample
-            print p
             curr_ids = np.random.choice(data.index.values, num_samples, p=p)
             sample_rows = pd.concat([sample_rows, data.loc[curr_ids]])
         else:
@@ -140,7 +138,6 @@ def accounting_sample_no_replace(total, data, accounting_column, prob_column=Non
 
     # check for probabilities
     p = get_probs(data, prob_column)
-    print p
 
     # shuffle the rows
     if p is None:

--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -6,8 +6,8 @@ import pandas as pd
 def get_probs(data, prob_column=None):
     """
     Checks for presence of a probability column and returns the result
-    as a numpy array. If the probabilities are weights (i.e. they don't)
-    sum to 1, then this will be recalculated.
+    as a numpy array. If the probabilities are weights (i.e. they don't
+    sum to 1), then this will be recalculated.
 
     Parameters
     ----------
@@ -24,14 +24,15 @@ def get_probs(data, prob_column=None):
     if prob_column is None:
         p = None
     else:
-        p = data[prob_column].values
+        p = data[prob_column].fillna(0).values
+        if p.sum() == 0:
+            p = np.ones(len(p))
         if round(p.sum(), 0) != 1:
             p = p / (1.0 * p.sum())
     return p
 
 
-def accounting_sample_replace(total, data, accounting_column,
-                              prob_column=None, exact=True, max_iterations=50):
+def accounting_sample_replace(total, data, accounting_column, prob_column=None, max_iterations=50):
     """
     Sample rows with accounting with replacement.
 
@@ -46,9 +47,6 @@ def accounting_sample_replace(total, data, accounting_column,
         If not provided then row counts will be used for accounting.
     prob_column: string, optional, default None
         Name of the column in the data to provide probabilities or weights.
-    exact: bool, optional, default True
-        If True, will attempt to match the total exactly. Otherwise it will be an
-        approximation.
     max_iterations: int, optional, default 50
         When using an accounting attribute, the maximum number of sampling iterations
         that will be applied.
@@ -57,7 +55,8 @@ def accounting_sample_replace(total, data, accounting_column,
     -------
     sample_rows : pandas.DataFrame
         Table containing the sample.
-
+    matched: bool
+        Indicates if the total was matched exactly.
     """
 
     # check for probabilities
@@ -71,31 +70,26 @@ def accounting_sample_replace(total, data, accounting_column,
     sample_rows = pd.DataFrame()
     closest = None
     closest_remain = total
+    matched = False
 
     for i in range(0, max_iterations):
 
         # stop if we've hit the control
         if remaining == 0:
-            break
-
-        # stop after the 1st iteration if we're approximating w/out probs
-        if (not exact) and i == 1 and p is None:
-            break
-
-        # stop afer the 2nd iteration if we're approximating w/ probs
-        if (not exact) and i == 2 and p is not None:
+            matched = True
             break
 
         # if sampling with probabilities, re-caclc the # of items per sample
         # after the initial sample, this way the sample size reflects the probabilities
         if p is not None and i == 1:
-            per_sample = sample_rows[accounting_column].sum / (1.0 * len(sample_rows))
+            per_sample = sample_rows[accounting_column].sum() / (1.0 * len(sample_rows))
 
         # update the sample
         num_samples = int(math.ceil(math.fabs(remaining) / per_sample))
 
         if remaining > 0:
             # we're short, add to the sample
+            print p
             curr_ids = np.random.choice(data.index.values, num_samples, p=p)
             sample_rows = pd.concat([sample_rows, data.loc[curr_ids]])
         else:
@@ -110,11 +104,10 @@ def accounting_sample_replace(total, data, accounting_column,
             closest_remain = abs(remaining)
             closest = sample_rows
 
-    return closest
+    return closest, matched
 
 
-def accounting_sample_no_replace(total, data, accounting_column,
-                                 prob_column=None, exact=True, max_iterations=50):
+def accounting_sample_no_replace(total, data, accounting_column, prob_column=None):
     """
     Samples rows with accounting without replacement.
 
@@ -131,14 +124,13 @@ def accounting_sample_no_replace(total, data, accounting_column,
     exact: bool, optional, default True
         If True, will attempt to match the total exactly. Otherwise it will be an
         approximation.
-    max_iterations: int, optional, default 50
-        When using an accounting attribute, the maximum number of sampling iterations
-        that will be applied.
 
     Returns
     -------
     sample_rows : pandas.DataFrame
         Table containing the sample.
+    matched: bool
+        Indicates if the total was matched exactly.
 
     """
 
@@ -148,62 +140,47 @@ def accounting_sample_no_replace(total, data, accounting_column,
 
     # check for probabilities
     p = get_probs(data, prob_column)
+    print p
 
-    closest = None
-    closest_shortage = total
+    # shuffle the rows
+    if p is None:
+        # random shuffle
+        shuff_idx = np.random.permutation(data.index.values)
+    else:
+        # weighted shuffle
+        ran_p = pd.Series(np.power(np.random.rand(len(p)), 1.0 / p), index=data.index)
+        ran_p.sort(ascending=False)
+        shuff_idx = ran_p.index.values
 
-    for i in range(0, max_iterations):
+    # get the initial sample
+    shuffle = data.loc[shuff_idx]
+    csum = np.cumsum(shuffle[accounting_column].values)
+    pos = np.searchsorted(csum, total, 'right')
+    sample = shuffle.iloc[:pos]
 
-        print i
+    # refine the sample
+    sample_idx = sample.index.values
+    sample_total = sample[accounting_column].sum()
+    shortage = total - sample_total
+    matched = False
 
-        # shuffle the rows
-        if p is None:
-            # random shuffle
-            shuff_idx = np.random.permutation(data.index.values)
-        else:
-            # weighted shuffle
-            shuff_idx = np.random.choice(data.index.values, len(data), replace=False, p=p)
-
-        # get the initial sample
-        shuffle = data.loc[shuff_idx]
-        csum = np.cumsum(shuffle[accounting_column].values)
-        pos = np.searchsorted(csum, total, 'right')
-        sample = shuffle.iloc[:pos]
-
-        # if we're just approximating we're done
-        if not exact:
-            return sample.copy()
-
-        # refine the sample
-        sample_idx = sample.index.values
-        sample_total = sample[accounting_column].sum()
-        shortage = total - sample_total
-
-        for idx, row in shuffle.iloc[pos:].iterrows():
-            if shortage == 0:
-                # we've matached
-                break
-
-            # add the current element if it doesnt exceed the total
-            cnt = row[accounting_column]
-            if cnt <= shortage:
-                sample_idx = np.append(sample_idx, idx)
-                shortage -= cnt
-
-        # we've looped through all the elements, compare with other iterations
+    for idx, row in shuffle.iloc[pos:].iterrows():
         if shortage == 0:
-            closest = shuffle.loc[sample_idx].copy()
+            # we've matached
+            matched = True
             break
-        else:
-            if abs(shortage) < closest_shortage:
-                closest = shuffle.loc[sample_idx].copy()
-                closest_shortage = shortage
 
-    return closest
+        # add the current element if it doesnt exceed the total
+        cnt = row[accounting_column]
+        if cnt <= shortage:
+            sample_idx = np.append(sample_idx, idx)
+            shortage -= cnt
+
+    return shuffle.loc[sample_idx].copy(), matched
 
 
 def sample_rows(total, data, replace=True, accounting_column=None,
-                max_iterations=50, prob_column=None, exact=True):
+                max_iterations=50, prob_column=None, return_status=False):
     """
     Samples and returns rows from a data frame while matching a desired control total. The total may
     represent a simple row count or may attempt to match a sum/quantity from an accounting column.
@@ -221,7 +198,9 @@ def sample_rows(total, data, replace=True, accounting_column=None,
         If not provided then row counts will be used for accounting.
     max_iterations: int, optional, default 50
         When using an accounting attribute, the maximum number of sampling iterations
-        that will be applied.
+        that will be applied. Only applicable when sampling with replacement.
+    return_status: bool, optional, default True
+        If True, will also return a bool indicating if the total was matched exactly.
 
     Returns
     -------
@@ -233,11 +212,20 @@ def sample_rows(total, data, replace=True, accounting_column=None,
     if accounting_column is None:
         if replace is False and total > len(data.index.values):
             raise ValueError('Control total exceeds the available samples')
-        return data.loc[np.random.choice(data.index.values, total, replace=replace)].copy()
+        rows = data.loc[np.random.choice(data.index.values, total, replace=replace)].copy()
+        matched = True
 
-    if replace:
-        func = accounting_sample_replace
+    # sample with accounting
     else:
-        func = accounting_sample_no_replace
+        if replace:
+            rows, matched = accounting_sample_replace(
+                total, data, accounting_column, prob_column, max_iterations)
+        else:
+            rows, matched = accounting_sample_no_replace(
+                total, data, accounting_column, prob_column)
 
-    return func(total, data, accounting_column, prob_column, exact, max_iterations)
+    # return the results
+    if return_status:
+        return rows, matched
+    else:
+        return rows

--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -27,7 +27,7 @@ def get_probs(data, prob_column=None):
         p = data[prob_column].fillna(0).values
         if p.sum() == 0:
             p = np.ones(len(p))
-        if round(p.sum(), 0) != 1:
+        if abs(p.sum() - 1.0) > 1e-8:
             p = p / (1.0 * p.sum())
     return p
 

--- a/urbansim/utils/tests/test_sampling.py
+++ b/urbansim/utils/tests/test_sampling.py
@@ -2,7 +2,21 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from urbansim.utils.sampling import sample_rows
+from urbansim.utils.sampling import sample_rows, get_probs
+
+
+def test_get_probs():
+    df = pd.DataFrame({
+        'a': np.zeros(4),
+        'b': [0.25, 0.25, 0.25, 0.25],
+        'c': np.ones(4)
+    })
+
+    assert get_probs(df) is None
+    expected = [0.25, 0.25, 0.25, 0.25]
+    assert (get_probs(df, 'a') == expected).all()
+    assert (get_probs(df, 'b') == expected).all()
+    assert (get_probs(df, 'c') == expected).all()
 
 
 @pytest.fixture(scope='function')
@@ -18,10 +32,14 @@ def random_df(request):
         np.random.set_state(old_state)
 
     request.addfinalizer(fin)
-    np.random.seed(1)
+    np.random.seed(123)
     return pd.DataFrame(
-        {'some_count': np.random.randint(1, 8, 20)},
-        index=range(0, 20))
+        {
+            'some_count': np.random.randint(1, 8, 20),
+            'p': np.arange(20)
+        },
+        index=range(0, 20)
+    )
 
 
 def test_no_accounting_with_replacment(random_df):
@@ -45,14 +63,31 @@ def test_no_accounting_no_replacment_raises(random_df):
 
 def test_accounting_with_replacment(random_df):
     control = 10
-    rows = sample_rows(control, random_df, accounting_column='some_count')
+
+    rows, matched = sample_rows(
+        control, random_df, accounting_column='some_count', return_status=True)
     assert control == rows['some_count'].sum()
+    assert matched
+
+    # test with probabilities
+    rows, matched = sample_rows(
+        control, random_df, accounting_column='some_count', prob_column='p', return_status=True)
+    assert control == rows['some_count'].sum()
+    assert matched
 
 
 def test_accounting_no_replacment(random_df):
     control = 10
-    rows = sample_rows(control, random_df, accounting_column='some_count', replace=False)
+    rows, matched = sample_rows(
+        control, random_df, accounting_column='some_count', replace=False, return_status=True)
     assert control == rows['some_count'].sum()
+    assert matched
+
+    # test with probabilities
+    rows, matched = sample_rows(control, random_df, accounting_column='some_count',
+                                replace=False, prob_column='p', return_status=True)
+    assert control == rows['some_count'].sum()
+    assert matched
 
 
 def test_accounting_no_replacment_raises(random_df):

--- a/urbansim/utils/tests/test_sampling.py
+++ b/urbansim/utils/tests/test_sampling.py
@@ -64,6 +64,7 @@ def test_no_accounting_no_replacment(random_df):
         control, random_df, replace=False, prob_column='p', return_status=True)
     assert control == len(rows)
     assert matched
+    assert rows.index.is_unique
 
 
 def test_no_accounting_no_replacment_raises(random_df):
@@ -88,20 +89,31 @@ def test_accounting_with_replacment(random_df):
 
 
 def test_accounting_no_replacment(random_df):
+
+    def assert_results(control, rows, matched):
+        assert control == rows['some_count'].sum()
+        assert matched
+        assert rows.index.is_unique
+
     control = 10
     rows, matched = sample_rows(
         control, random_df, accounting_column='some_count', replace=False, return_status=True)
-    assert control == rows['some_count'].sum()
-    assert matched
+    assert_results(control, rows, matched)
 
     # test with probabilities
     rows, matched = sample_rows(control, random_df, accounting_column='some_count',
                                 replace=False, prob_column='p', return_status=True)
-    assert control == rows['some_count'].sum()
-    assert matched
+    assert_results(control, rows, matched)
 
 
 def test_accounting_no_replacment_raises(random_df):
     control = 200
     with pytest.raises(ValueError):
         sample_rows(control, random_df, accounting_column='some_count', replace=False)
+
+
+def test_non_unique_raises(random_df):
+    control = 10
+    df = pd.concat([random_df, random_df])
+    with pytest.raises(ValueError):
+        sample_rows(control, df)

--- a/urbansim/utils/tests/test_sampling.py
+++ b/urbansim/utils/tests/test_sampling.py
@@ -47,12 +47,23 @@ def test_no_accounting_with_replacment(random_df):
     rows = sample_rows(control, random_df)
     assert control == len(rows)
 
+    # test with probabilities
+    rows, matched = sample_rows(
+        control, random_df, prob_column='p', return_status=True)
+    assert control == len(rows)
+    assert matched
+
 
 def test_no_accounting_no_replacment(random_df):
     control = 3
     rows = sample_rows(control, random_df, replace=False)
     print random_df
     assert control == len(rows)
+
+    rows, matched = sample_rows(
+        control, random_df, replace=False, prob_column='p', return_status=True)
+    assert control == len(rows)
+    assert matched
 
 
 def test_no_accounting_no_replacment_raises(random_df):


### PR DESCRIPTION
This addresses feedback when the accounting total is not met (#178) and also providing probability distributions to influence the sample (#149).

To obtain feedback, set the return_status argument to True, and this will return both the sampled rows and the status. If False, then only the sampled rows will be returned. This is still the default, so as to not break any existing calls. 

To provide sampling probabilities, set the prob_column argument to the name of the column in the data frame containing the weights or probabilities. These values will be normalized so they sum to 1, if they do not already.  

The logic for sampling with accounting but without replacement has been changed to hopefully be more robust. 
