### PR TITLE
Fix type error in predict_from_cfg methods in DCM

### DIFF
--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -833,7 +833,8 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
                  "and only %d choosers") %
                 (len(alternatives), len(choosers)))
             idxes = np.random.choice(
-                alternatives.index, size=len(choosers) * alternative_ratio,
+                alternatives.index, size=int(len(choosers) *
+                                             alternative_ratio),
                 replace=False)
             alternatives = alternatives.loc[idxes]
             logger.info(
@@ -1848,7 +1849,7 @@ class SegmentedMNLDiscreteChoiceModel(DiscreteChoiceModel):
                 (len(alternatives), len(choosers)))
             idxes = np.random.choice(
                 alternatives.index,
-                size=np.floor(len(choosers) * alternative_ratio),
+                size=int(np.floor(len(choosers) * alternative_ratio)),
                 replace=False)
             alternatives = alternatives.loc[idxes]
             logger.info(


### PR DESCRIPTION
Running a standard parcel model with numpy 1.12 installed hits a `TypeError` in the `predict_from_cfg` method of the segmented DCM (this also affects the base MNL DCM as well). See traceback:

```
  File "/Users/paulsohn/Documents/sanfran_urbansim/models.py", line 47, in hlcm_simulate
    "vacant_residential_units")
  File "/Users/paulsohn/Documents/sanfran_urbansim/utils.py", line 191, in lcm_simulate
    new_units, _ = yaml_to_class(cfg).predict_from_cfg(movers, units, cfg)
  File "/Users/paulsohn/anaconda2/lib/python2.7/site-packages/urbansim-3.1.dev0-py2.7.egg/urbansim/models/dcm.py", line 1852, in predict_from_cfg
    replace=False)
  File "mtrand.pyx", line 1176, in mtrand.RandomState.choice (numpy/random/mtrand/mtrand.c:18822)
TypeError: 'numpy.float64' object cannot be interpreted as an index
```

Running this in numpy 1.11 returns the deprecation warning below, so this behavior was probably expected. 

```
/Users/paulsohn/anaconda2/lib/python2.7/site-packages/urbansim-3.1.dev0-py2.7.egg/urbansim/models/dcm.py:1852: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  replace=False)
```

Simply forcing an integer in line 1852 fixes this issue for me, and I assume the change to line 836 is also necessary. 