### PR TITLE
Two more TypeError fixes related to numpy 1.12

### DIFF
--- a/urbansim/urbanchoice/tests/test_mnl.py
+++ b/urbansim/urbanchoice/tests/test_mnl.py
@@ -94,7 +94,7 @@ def choosers(test_data):
 @pytest.fixture
 def chosen(df, num_alts, test_data):
     return df[test_data['column']].values.astype('int').reshape(
-        (len(df) / num_alts, num_alts))
+        (int(len(df) / num_alts), num_alts))
 
 
 @pytest.fixture

--- a/urbansim/utils/sampling.py
+++ b/urbansim/utils/sampling.py
@@ -215,7 +215,7 @@ def sample_rows(total, data, replace=True, accounting_column=None,
             raise ValueError('Control total exceeds the available samples')
         p = get_probs(prob_column)
         rows = data.loc[np.random.choice(
-            data.index.values, total, replace=replace, p=p)].copy()
+            data.index.values, int(total), replace=replace, p=p)].copy()
         matched = True
 
     # sample with accounting


### PR DESCRIPTION
This is an extension to #182. Numpy 1.12 raises a `TypeError` when floats are passed to a parameter that wants an integer in two places that interact with urbansim:

* The `size` parameter in [numpy.random.choice](https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.choice.html)
* The `newshape` parameter in [numpy.reshape](https://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html)

These two issues have been fixed in a couple of places by simply casting to int again.