### PR TITLE
Change regression.py unit test based on change in statsmodels 0.8

### DIFF
--- a/urbansim/models/tests/test_regression.py
+++ b/urbansim/models/tests/test_regression.py
@@ -71,9 +71,10 @@ def test_predict_with_nans():
 
     fit = regression.fit_model(df.loc[['a', 'b', 'e']], None, 'col1 ~ col2')
 
-    with pytest.raises(ModelEvaluationError):
-        regression.predict(
-            df.loc[['c', 'd']], None, fit)
+    predict = regression.predict(
+        df.loc[['c', 'd']], None, fit)
+
+    assert np.isnan(predict.loc['c'])
 
 
 def test_rhs():


### PR DESCRIPTION
Addresses #185. [Statsmodels 0.8](http://www.statsmodels.org/stable/release/version0.8.html), released in February, changes the behavior of the `predict()` method when a DataFrame is passed to the exog argument: it used to drop a row from the returned prediction column if any of the inputs for that row were nan, it now returns that row with nan. 

The new behavior is more intuitive than before, and since most urbansim models are probably set up to drop nans before passing to `predict()` anyway, we'll just change the unit test here to make sure the appropriate nan is returned. 