### PR TITLE
merging in the UAL changes uncovered this performance issue in UrbanSim

### DIFF
--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -1182,7 +1182,7 @@ class MNLDiscreteChoiceModelGroup(DiscreteChoiceModel):
 
         for name, df in self._iter_groups(choosers):
             choices = self.models[name].predict(df, alternatives, debug=debug)
-            if self.remove_alts:
+            if self.remove_alts and len(alternatives) > 0:
                 alternatives = alternatives.loc[
                     ~alternatives.index.isin(choices)]
             results.append(choices)


### PR DESCRIPTION
I can't actually explain why, but this one tiny change speeds the simulation up 25 minutes for a 70 minutes simulation. 

There should be no behavior difference here - it just protects the case where there are no alternatives, which would return the same empty list you started with inside this loop.  I don't really understand why it would take so long, and in basic tests outside of UrbanSim I can't recreate it.  It seems like a harmless change though, so merging it to master seems innocuous.