### PR TITLE
Bump statsmodels version number

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -36,7 +36,7 @@ UrbanSim depends on the following libraries, most of which are in Anaconda:
 * `pyyaml <http://pyyaml.org/>`__ >= 3.10
 * `scipy <http://scipy.org>`__ >= 0.13.3
 * `simplejson <http://simplejson.readthedocs.org/en/latest/>`__ >= 3.3.3
-* `statsmodels <http://statsmodels.sourceforge.net/stable/index.html>`__ >= 0.5.0
+* `statsmodels <http://statsmodels.sourceforge.net/stable/index.html>`__ >= 0.8.0
 * `tables <http://www.pytables.org/moin>`__ >= 3.1.0
 * `toolz <http://toolz.readthedocs.org/en/latest/>`__ >= 0.7
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'pyyaml>=3.10',
         'scipy>=0.13.3',
         'simplejson>=3.3',
-        'statsmodels>=0.5.0',
+        'statsmodels>=0.8.0',
         'tables>=3.1.0',
         'toolz>=0.7.0',
         'zbox>=1.2'


### PR DESCRIPTION
Change required version of statsmodels in setup.py and in documentation, since old versions have different behavior in `predict()` method and are incompatible with new unit tests.