### PR TITLE
fixed boundary case in supply and demand

### DIFF
--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -1135,6 +1135,9 @@ class MNLDiscreteChoiceModelGroup(DiscreteChoiceModel):
             Summed probabilities from each segment added together.
 
         """
+        if len(alternatives) == 0 or len(choosers) == 0:
+            return pd.Series()
+
         logger.debug(
             'start: calculate summed probabilities in LCM group {}'.format(
                 self.name))


### PR DESCRIPTION
We protect against the boundary case of having no choosers in the predict method, but this gets circumvented and is still a problem with the supply and demand code.

I was hoping to protect against this outside of urbansim, but we don't know how many choosers there are until the predict_filters gets run, and that happens in urbansim.