### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: false
 python:
 - '2.7'
+- '3.5'
 install:
 - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
   -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,7 @@ install:
   cytoolz ipython-notebook jinja2 matplotlib numpy pandas patsy pip scipy
   statsmodels pytables pytest pyyaml toolz
 - source activate test-environment
-# Update orca installation once version 1.4.0 is released
-- pip install https://github.com/udst/orca/archive/master.zip
-- pip install osmnet pandana bottle simplejson zbox
+- pip install orca osmnet pandana bottle simplejson zbox
 - pip install pytest-cov coveralls pycodestyle
 - pip install .
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,23 @@ install:
 - conda update -q conda
 - conda info -a
 - >
-  conda create -q -c synthicity -n test-environment
+  conda create -q -n test-environment
   python=$TRAVIS_PYTHON_VERSION
   cytoolz ipython-notebook jinja2 matplotlib numpy pandas patsy pip scipy
-  statsmodels pandana pytables pytest pyyaml toolz
+  statsmodels pytables pytest pyyaml toolz
 - source activate test-environment
-- pip install bottle orca simplejson zbox
-- pip install pytest-cov coveralls pep8
+# Update orca installation once version 1.4.0 is released
+- pip install https://github.com/udst/orca/archive/master.zip
+- pip install osmnet pandana bottle simplejson zbox
+- pip install pytest-cov coveralls pycodestyle
 - pip install .
 before_script:
-- git clone https://github.com/synthicity/sanfran_urbansim.git
-- cd sanfran_urbansim; ipython nbconvert --to python Simulation.ipynb
+# Update sanfran_urbansim clone once python3 branch is merged
+- git clone -b python3 https://github.com/udst/sanfran_urbansim.git
+- cd sanfran_urbansim; jupyter nbconvert --to python Simulation.ipynb
 - cd ..
 script:
-- pep8 urbansim scripts
+- pycodestyle urbansim scripts
 - py.test --cov urbansim --cov-report term-missing
 - cd sanfran_urbansim; python Simulation.py
 - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,7 @@ install:
   - "conda create -q -n test-environment python=%PYTHON_VERSION% cytoolz ipython-notebook jinja2 matplotlib numpy pandas patsy pip scipy statsmodels pytables pytest pyyaml toolz"
   - activate test-environment
   - conda install -c conda-forge shapely geopandas
-  # Update orca installation once version 1.4.0 is released
-  - pip install https://github.com/udst/orca/archive/master.zip
-  - pip install osmnet pandana bottle simplejson zbox
+  - pip install orca osmnet pandana bottle simplejson zbox
   - pip install pycodestyle
   - pip install .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
   matrix:
     - PYTHON_VERSION: 2.7
       MINICONDA: C:\Miniconda
+    - PYTHON_VERSION: 3.5
+      MINICONDA: C:\Miniconda3
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
@@ -16,16 +18,19 @@ install:
   - "conda create -q -n test-environment python=%PYTHON_VERSION% cytoolz ipython-notebook jinja2 matplotlib numpy pandas patsy pip scipy statsmodels pytables pytest pyyaml toolz"
   - activate test-environment
   - conda install -c conda-forge shapely geopandas
-  - pip install pandana bottle orca simplejson zbox
-  - pip install pep8
+  # Update orca installation once version 1.4.0 is released
+  - pip install https://github.com/udst/orca/archive/master.zip
+  - pip install osmnet pandana bottle simplejson zbox
+  - pip install pycodestyle
   - pip install .
 
 before_test:
-  - git clone https://github.com/synthicity/sanfran_urbansim.git
-  - cd sanfran_urbansim & ipython nbconvert --to python Simulation.ipynb
+# Update sanfran_urbansim clone once python3 branch is merged
+  - git clone -b python3 https://github.com/udst/sanfran_urbansim.git
+  - cd sanfran_urbansim & jupyter nbconvert --to python Simulation.ipynb
   - cd..
 
 test_script:
-  - pep8 urbansim scripts
+  - pycodestyle urbansim scripts
   - pytest urbansim
   - cd sanfran_urbansim & python Simulation.py

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'numpy>=1.8.0',
         'orca>=1.1',
         'pandas>=0.15.0',
-        'patsy>=0.2.1',
+        'patsy>=0.3.0',
         'prettytable>=0.7.2',
         'pyyaml>=3.10',
         'scipy>=0.13.3',

--- a/urbansim/developer/developer.py
+++ b/urbansim/developer/developer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 
 import pandas as pd
 import numpy as np

--- a/urbansim/developer/developer.py
+++ b/urbansim/developer/developer.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import pandas as pd
 import numpy as np
 
@@ -90,13 +92,14 @@ class Developer(object):
         number_of_units : int
             the number of units that need to be built
         """
-        print "Number of agents: {:,}".format(num_agents)
-        print "Number of agent spaces: {:,}".format(int(num_units))
+        print("Number of agents: {:,}".format(num_agents))
+        print("Number of agent spaces: {:,}".format(int(num_units)))
         assert target_vacancy < 1.0
         target_units = int(max(num_agents / (1 - target_vacancy) - num_units, 0))
-        print "Current vacancy = {:.2f}".format(1 - num_agents / float(num_units))
-        print "Target vacancy = {:.2f}, target of new units = {:,}".\
-            format(target_vacancy, target_units)
+        print("Current vacancy = {:.2f}"
+              .format(1 - num_agents / float(num_units)))
+        print("Target vacancy = {:.2f}, target of new units = {:,}"
+              .format(target_vacancy, target_units))
         return target_units
 
     def pick(self, form, target_units, parcel_size, ave_unit_size,
@@ -190,12 +193,12 @@ class Developer(object):
         df = df[df.net_units > 0]
 
         if len(df) == 0:
-            print "WARNING THERE ARE NO FEASIBLE BUILDING TO CHOOSE FROM"
+            print("WARNING THERE ARE NO FEASIBLE BUILDING TO CHOOSE FROM")
             return
 
         # print "Describe of net units\n", df.net_units.describe()
-        print "Sum of net units that are profitable: {:,}".\
-            format(int(df.net_units.sum()))
+        print("Sum of net units that are profitable: {:,}"
+              .format(int(df.net_units.sum())))
 
         if profit_to_prob_func:
             p = profit_to_prob_func(df)
@@ -204,8 +207,8 @@ class Developer(object):
             p = df.max_profit_per_size.values / df.max_profit_per_size.sum()
 
         if df.net_units.sum() < target_units:
-            print "WARNING THERE WERE NOT ENOUGH PROFITABLE UNITS TO " \
-                  "MATCH DEMAND"
+            print("WARNING THERE WERE NOT ENOUGH PROFITABLE UNITS TO",
+                  "MATCH DEMAND")
             build_idx = df.index.values
         elif target_units <= 0:
             build_idx = []

--- a/urbansim/developer/sqftproforma.py
+++ b/urbansim/developer/sqftproforma.py
@@ -197,7 +197,7 @@ class SqFtProFormaConfig(object):
         self.parking_rates = np.array([self.parking_rates[use] for use in self.uses])
         self.res_ratios = {}
         assert len(self.uses) == len(self.residential_uses)
-        for k, v in self.forms.iteritems():
+        for k, v in self.forms.items():
             self.forms[k] = np.array([self.forms[k].get(use, 0.0) for use in self.uses])
             # normalize if not already
             self.forms[k] /= self.forms[k].sum()
@@ -212,23 +212,23 @@ class SqFtProFormaConfig(object):
         fars = pd.Series(self.fars)
         assert len(fars[fars > 20]) == 0
         assert len(fars[fars <= 0]) == 0
-        for k, v in self.forms.iteritems():
+        for k, v in self.forms.items():
             assert isinstance(v, dict)
-            for k2, v2 in self.forms[k].iteritems():
+            for k2, v2 in self.forms[k].items():
                 assert isinstance(k2, str)
                 assert isinstance(v2, float)
-            for k2, v2 in self.forms[k].iteritems():
+            for k2, v2 in self.forms[k].items():
                 assert isinstance(k2, str)
                 assert isinstance(v2, float)
-        for k, v in self.parking_rates.iteritems():
+        for k, v in self.parking_rates.items():
             assert isinstance(k, str)
             assert k in self.uses
             assert 0 <= v < 5
-        for k, v in self.parking_sqft_d.iteritems():
+        for k, v in self.parking_sqft_d.items():
             assert isinstance(k, str)
             assert k in self.parking_configs
             assert 50 <= v <= 1000
-        for k, v in self.parking_sqft_d.iteritems():
+        for k, v in self.parking_sqft_d.items():
             assert isinstance(k, str)
             assert k in self.parking_cost_d
             assert 10 <= v <= 300
@@ -237,7 +237,7 @@ class SqFtProFormaConfig(object):
             if np.isinf(v):
                 continue
             assert 0 <= v <= 1000
-        for k, v in self.costs.iteritems():
+        for k, v in self.costs.items():
             assert isinstance(k, str)
             assert k in self.uses
             for i in v:
@@ -317,7 +317,7 @@ class SqFtProForma(object):
 
         # get all the building forms we can use
         keys = c.forms.keys()
-        keys.sort()
+        keys = sorted(keys)
         df_d = {}
         for name in keys:
             # get the use distribution for each
@@ -671,7 +671,7 @@ class SqFtProForma(object):
 
         df_d = self.dev_d
         keys = df_d.keys()
-        keys.sort()
+        keys = sorted(keys)
         for key in keys:
             logger.debug("\n" + str(key) + "\n")
             logger.debug(df_d[key])
@@ -680,7 +680,7 @@ class SqFtProForma(object):
             logger.debug(self.get_ave_cost_sqft(form, "surface"))
 
         keys = c.forms.keys()
-        keys.sort()
+        keys = sorted(keys)
         cnt = 1
         share = None
         fig = plt.figure(figsize=(12, 3 * len(keys)))

--- a/urbansim/developer/sqftproforma.py
+++ b/urbansim/developer/sqftproforma.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 import pandas as pd
 import logging

--- a/urbansim/maps/dframe_explorer.py
+++ b/urbansim/maps/dframe_explorer.py
@@ -15,6 +15,7 @@ def enable_cors():
     response.headers['Access-Control-Allow-Headers'] = \
         'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
 
+
 DFRAMES = {}
 CONFIG = None
 

--- a/urbansim/maps/dframe_explorer.py
+++ b/urbansim/maps/dframe_explorer.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from bottle import route, response, run, hook, static_file
 from urbansim.utils import yamlio
 import simplejson
@@ -31,13 +33,13 @@ def map_query(table, filter, groupby, field, agg):
     df = DFRAMES[table]
 
     if field not in df.columns:
-        print "Col not found, trying eval:", field
+        print("Col not found, trying eval:", field)
         df["eval"] = df.eval(field)
         field = "eval"
 
     cmd = "df%s.groupby('%s')['%s'].%s" % \
           (filter, groupby, field, agg)
-    print cmd
+    print(cmd)
     results = eval(cmd)
     results[results == np.inf] = np.nan
     results = yamlio.series_to_yaml_safe(results.dropna())

--- a/urbansim/models/supplydemand.py
+++ b/urbansim/models/supplydemand.py
@@ -2,6 +2,8 @@
 Tools for modeling how supply and demand affect real estate prices.
 
 """
+from __future__ import division
+
 import logging
 
 import numpy as np

--- a/urbansim/models/tests/test_regression.py
+++ b/urbansim/models/tests/test_regression.py
@@ -1,6 +1,9 @@
 import os
 import tempfile
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import numpy as np
 import numpy.testing as npt

--- a/urbansim/models/tests/test_transition.py
+++ b/urbansim/models/tests/test_transition.py
@@ -436,7 +436,8 @@ def test_update_linked_table(basic_df):
     npt.assert_array_equal(updated[col_name].values, [1, 2, 3, 4, 5, 7, 6])
     pdt.assert_series_equal(
         updated['y'],
-        pd.Series([6, 7, 8, 9, 6, 6, 8], index=updated.index, name='y'))
+        pd.Series([6, 7, 8, 9, 6, 6, 8], index=updated.index, name='y'),
+        check_dtype=False)
 
 
 def test_updated_linked_table_remove_only(basic_df):

--- a/urbansim/models/tests/test_util.py
+++ b/urbansim/models/tests/test_util.py
@@ -43,7 +43,7 @@ def test_apply_filter_query(test_df):
     expected = pd.DataFrame(
         {'col1': [2], 'col2': [7]},
         index=['c'])
-    pdt.assert_frame_equal(filtered, expected)
+    pdt.assert_frame_equal(filtered, expected, check_dtype=False)
 
 
 def test_apply_filter_query_empty(test_df):
@@ -61,14 +61,14 @@ def test_apply_filter_query_or(test_df):
     expected = pd.DataFrame(
         {'col1': [0, 4], 'col2': [5, 9]},
         index=['a', 'e'])
-    pdt.assert_frame_equal(filtered, expected)
+    pdt.assert_frame_equal(filtered, expected, check_dtype=False)
 
 
 def test_apply_filter_query_no_filter(test_df):
     filters = []
     filtered = util.apply_filter_query(test_df, filters)
     expected = test_df
-    pdt.assert_frame_equal(filtered, expected)
+    pdt.assert_frame_equal(filtered, expected, check_dtype=False)
 
 
 def test_apply_filter_query_str(test_df):
@@ -78,7 +78,7 @@ def test_apply_filter_query_str(test_df):
         {'col1': [0, 1, 2],
          'col2': [5, 6, 7]},
         index=['a', 'b', 'c'])
-    pdt.assert_frame_equal(filtered, expected)
+    pdt.assert_frame_equal(filtered, expected, check_dtype=False)
 
 
 @pytest.mark.parametrize('name, val, filter_exp', [

--- a/urbansim/models/tests/test_util.py
+++ b/urbansim/models/tests/test_util.py
@@ -145,8 +145,12 @@ class Test_str_model_expression(object):
 
 
 def test_sorted_groupby():
+    try:
+        letters = string.lowercase
+    except AttributeError:
+        letters = string.ascii_lowercase
     df = pd.DataFrame(
-        {'alpha': np.random.choice(list(string.lowercase), 100),
+        {'alpha': np.random.choice(list(letters), 100),
          'num': np.random.randint(100)})
     sorted_df = df.sort('alpha')
 

--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -515,7 +515,7 @@ class TransitionModel(object):
         with log_start_finish('add/remove rows', logger):
             updated, added, copied, removed = self.transitioner(data, year)
 
-        for table_name, (table, col) in linked_tables.iteritems():
+        for table_name, (table, col) in linked_tables.items():
             logger.debug('updating linked table {}'.format(table_name))
             updated_links[table_name] = \
                 _update_linked_table(table, col, added, copied, removed)

--- a/urbansim/models/util.py
+++ b/urbansim/models/util.py
@@ -5,7 +5,10 @@ Utilities used within the ``urbansim.models`` package.
 import collections
 import logging
 import numbers
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 from tokenize import generate_tokens, NAME
 
 import numpy as np

--- a/urbansim/tests/test_accounts.py
+++ b/urbansim/tests/test_accounts.py
@@ -66,9 +66,10 @@ def test_column_names_from_metadata():
     cnfm = accounts._column_names_from_metadata
 
     assert cnfm([]) == []
-    assert cnfm([{'a': 1, 'b': 2}]) == ['a', 'b']
-    assert cnfm([{'a': 1}, {'b': 2}]) == ['a', 'b']
-    assert cnfm([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]) == ['a', 'b']
+    # Sort to ensure order for tests
+    assert sorted(cnfm([{'a': 1, 'b': 2}])) == ['a', 'b']
+    assert sorted(cnfm([{'a': 1}, {'b': 2}])) == ['a', 'b']
+    assert sorted(cnfm([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}])) == ['a', 'b']
 
 
 def test_to_frame(acc, acc_bal):

--- a/urbansim/urbanchoice/interaction.py
+++ b/urbansim/urbanchoice/interaction.py
@@ -9,7 +9,7 @@ import logging
 import numpy as np
 import pandas as pd
 
-import pmat
+from . import pmat
 
 logger = logging.getLogger(__name__)
 GPU = False

--- a/urbansim/urbanchoice/interaction.py
+++ b/urbansim/urbanchoice/interaction.py
@@ -35,7 +35,7 @@ def mnl_interaction_dataset(choosers, alternatives, SAMPLE_SIZE,
         isin = chosenalts.isin(alternatives.index)
         try:
             removing = isin.value_counts().loc[False]
-        except:
+        except Exception:
             removing = None
         if removing:
             logger.info((

--- a/urbansim/urbanchoice/mnl.py
+++ b/urbansim/urbanchoice/mnl.py
@@ -33,7 +33,8 @@ def mnl_probs(data, beta, numalts):
     utilities = beta.multiply(data)
     if numalts == 0:
         raise Exception("Number of alternatives is zero")
-    utilities.reshape(numalts, utilities.size() / numalts)
+    # TODO confirm we want floor division here
+    utilities.reshape(numalts, utilities.size() // numalts)
 
     exponentiated_utility = utilities.exp(inplace=True)
     if clamp:
@@ -67,7 +68,8 @@ def mnl_loglik(beta, data, chosen, numalts, weights=None, lcgrad=False,
                stderr=0):
     logger.debug('start: calculate MNL log-likelihood')
     numvars = beta.size
-    numobs = data.size() / numvars / numalts
+    # TODO confirm we want floor division here
+    numobs = data.size() // numvars // numalts
 
     beta = np.reshape(beta, (1, beta.size))
     beta = PMAT(beta, data.typ)
@@ -165,7 +167,8 @@ def mnl_simulate(data, coeff, numalts, GPU=False, returnprobs=True):
         probs = PMAT(probs.get_mat())
 
     probs = probs.cumsum(axis=0)
-    r = pmat.random(probs.size() / numalts)
+    # TODO confirm we want floor division here
+    r = pmat.random(probs.size() // numalts)
     choices = probs.subtract(r, inplace=True).firstpositive(axis=0)
 
     logger.debug('finish: MNL simulation')
@@ -219,7 +222,8 @@ def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(-3, 3),
     atype = 'numpy' if not GPU else 'cuda'
 
     numvars = data.shape[1]
-    numobs = data.shape[0] / numalts
+    # TODO confirm we want floor division here
+    numobs = data.shape[0] // numalts
 
     if chosen is None:
         chosen = np.ones((numobs, numalts))  # used for latent classes

--- a/urbansim/urbanchoice/mnl.py
+++ b/urbansim/urbanchoice/mnl.py
@@ -12,8 +12,8 @@ import numpy as np
 import pandas as pd
 import scipy.optimize
 
-import pmat
-from pmat import PMAT
+from . import pmat
+from .pmat import PMAT
 
 from ..utils.logutil import log_start_finish
 

--- a/urbansim/urbanchoice/mnl.py
+++ b/urbansim/urbanchoice/mnl.py
@@ -33,7 +33,6 @@ def mnl_probs(data, beta, numalts):
     utilities = beta.multiply(data)
     if numalts == 0:
         raise Exception("Number of alternatives is zero")
-    # TODO confirm we want floor division here
     utilities.reshape(numalts, utilities.size() // numalts)
 
     exponentiated_utility = utilities.exp(inplace=True)
@@ -68,7 +67,6 @@ def mnl_loglik(beta, data, chosen, numalts, weights=None, lcgrad=False,
                stderr=0):
     logger.debug('start: calculate MNL log-likelihood')
     numvars = beta.size
-    # TODO confirm we want floor division here
     numobs = data.size() // numvars // numalts
 
     beta = np.reshape(beta, (1, beta.size))
@@ -167,7 +165,6 @@ def mnl_simulate(data, coeff, numalts, GPU=False, returnprobs=True):
         probs = PMAT(probs.get_mat())
 
     probs = probs.cumsum(axis=0)
-    # TODO confirm we want floor division here
     r = pmat.random(probs.size() // numalts)
     choices = probs.subtract(r, inplace=True).firstpositive(axis=0)
 
@@ -222,7 +219,6 @@ def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(-3, 3),
     atype = 'numpy' if not GPU else 'cuda'
 
     numvars = data.shape[1]
-    # TODO confirm we want floor division here
     numobs = data.shape[0] // numalts
 
     if chosen is None:

--- a/urbansim/urbanchoice/pmat.py
+++ b/urbansim/urbanchoice/pmat.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from numpy.linalg import inv
 from numpy.core.umath_tests import inner1d
@@ -90,9 +92,11 @@ class PMAT:
 
     def reshape(self, rowlen, collen):
         if rowlen == -1:
-            rowlen = self.size() / collen
+            # TODO confirm we want floor division here
+            rowlen = self.size() // collen
         if collen == -1:
-            collen = self.size() / rowlen
+            # TODO confirm we want floor division here
+            collen = self.size() // rowlen
         if self.typ == 'numpy':
             self.mat = np.reshape(self.mat, (rowlen, collen), order='F')
             return self
@@ -146,7 +150,8 @@ class PMAT:
 
     def divide_by_row(self, rowvec, inplace=False):
         if self.typ == 'numpy':
-            return PMAT(self.mat / rowvec.mat)
+            # TODO confirm we want floor division here
+            return PMAT(self.mat // rowvec.mat)
         elif self.typ == 'cuda':
             if inplace:
                 rowvec.mat.reciprocal()

--- a/urbansim/urbanchoice/pmat.py
+++ b/urbansim/urbanchoice/pmat.py
@@ -150,8 +150,8 @@ class PMAT:
 
     def divide_by_row(self, rowvec, inplace=False):
         if self.typ == 'numpy':
-            # TODO confirm we want floor division here
-            return PMAT(self.mat // rowvec.mat)
+            # TODO confirm we want true division here
+            return PMAT(self.mat / rowvec.mat)
         elif self.typ == 'cuda':
             if inplace:
                 rowvec.mat.reciprocal()

--- a/urbansim/urbanchoice/pmat.py
+++ b/urbansim/urbanchoice/pmat.py
@@ -92,10 +92,8 @@ class PMAT:
 
     def reshape(self, rowlen, collen):
         if rowlen == -1:
-            # TODO confirm we want floor division here
             rowlen = self.size() // collen
         if collen == -1:
-            # TODO confirm we want floor division here
             collen = self.size() // rowlen
         if self.typ == 'numpy':
             self.mat = np.reshape(self.mat, (rowlen, collen), order='F')
@@ -150,7 +148,6 @@ class PMAT:
 
     def divide_by_row(self, rowvec, inplace=False):
         if self.typ == 'numpy':
-            # TODO confirm we want true division here
             return PMAT(self.mat / rowvec.mat)
         elif self.typ == 'cuda':
             if inplace:

--- a/urbansim/utils/misc.py
+++ b/urbansim/utils/misc.py
@@ -107,7 +107,7 @@ def get_run_number():
         f = open(os.path.join(os.getenv('DATA_HOME', "."), 'RUNNUM'), 'r')
         num = int(f.read())
         f.close()
-    except:
+    except Exception:
         num = 1
     f = open(os.path.join(os.getenv('DATA_HOME', "."), 'RUNNUM'), 'w')
     f.write(str(num + 1))

--- a/urbansim/utils/networks.py
+++ b/urbansim/utils/networks.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import logging
 import yaml
 
@@ -12,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def from_yaml(net, cfgname):
-    print "Computing accessibility variables"
+    print("Computing accessibility variables")
     cfg = yaml.load(open(misc.config(cfgname)))
 
     nodes = pd.DataFrame(index=net.node_ids)
@@ -23,7 +25,7 @@ def from_yaml(net, cfgname):
     for variable in cfg['variable_definitions']:
 
         name = variable["name"]
-        print "Computing %s" % name
+        print("Computing %s" % name)
 
         decay = variable.get("decay", "linear")
         agg = variable.get("aggregation", "sum")

--- a/urbansim/utils/testing.py
+++ b/urbansim/utils/testing.py
@@ -48,7 +48,7 @@ def assert_frames_equal(actual, expected, use_close=False):
                 comp(act_item, exp_item)
             except AssertionError as e:
                 raise AssertionError(
-                    e.message + '\n\nColumn: {!r}\nRow: {!r}'.format(j, i))
+                    str(e) + '\n\nColumn: {!r}\nRow: {!r}'.format(j, i))
 
 
 def assert_index_equal(left, right):

--- a/urbansim/utils/tests/test_misc.py
+++ b/urbansim/utils/tests/test_misc.py
@@ -42,10 +42,17 @@ def test_column_map_none(fta, ftb):
 
 
 def test_column_map(fta, ftb):
-    assert misc.column_map([fta, ftb], ['aa', 'by', 'bz']) == \
-        {'a': ['aa'], 'b': ['by', 'bz']}
-    assert misc.column_map([fta, ftb], ['by', 'bz']) == \
-        {'a': [], 'b': ['by', 'bz']}
+
+    result = misc.column_map([fta, ftb], ['aa', 'by', 'bz'])
+    # misc.column_map() does not guarantee order, so sort for testing
+    result_sorted = {k: sorted(v) for k, v in result.items()}
+
+    assert result_sorted == {'a': ['aa'], 'b': ['by', 'bz']}
+
+    result = misc.column_map([fta, ftb], ['by', 'bz'])
+    result_sorted = {k: sorted(v) for k, v in result.items()}
+
+    assert result_sorted == {'a': [], 'b': ['by', 'bz']}
 
 
 def test_dirs(clean_fake_data_home):
@@ -122,5 +129,5 @@ def test_misc_dffunctions(simple_dev_inputs):
 
 
 def test_column_list(fta, ftb):
-    assert misc.column_list([fta, ftb], ['aa', 'by', 'bz', 'c']) == \
-        ['aa', 'by', 'bz']
+    result = misc.column_list([fta, ftb], ['aa', 'by', 'bz', 'c'])
+    assert sorted(result) == ['aa', 'by', 'bz']

--- a/urbansim/utils/tests/test_sampling.py
+++ b/urbansim/utils/tests/test_sampling.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -57,7 +59,7 @@ def test_no_accounting_with_replacment(random_df):
 def test_no_accounting_no_replacment(random_df):
     control = 3
     rows = sample_rows(control, random_df, replace=False)
-    print random_df
+    print(random_df)
     assert control == len(rows)
 
     rows, matched = sample_rows(

--- a/urbansim/utils/tests/test_testing.py
+++ b/urbansim/utils/tests/test_testing.py
@@ -10,7 +10,7 @@ def test_frames_equal_not_frames():
     with pytest.raises(AssertionError) as info:
         testing.assert_frames_equal(frame, 1)
 
-    assert info.value.message == 'Inputs must both be pandas DataFrames.'
+    assert str(info.value) == 'Inputs must both be pandas DataFrames.'
 
 
 def test_frames_equal_mismatched_columns():
@@ -20,7 +20,7 @@ def test_frames_equal_mismatched_columns():
     with pytest.raises(AssertionError) as info:
         testing.assert_frames_equal(actual, expected)
 
-    assert info.value.message == "Expected column 'a' not found."
+    assert str(info.value) == "Expected column 'a' not found."
 
 
 def test_frames_equal_mismatched_rows():
@@ -30,7 +30,7 @@ def test_frames_equal_mismatched_rows():
     with pytest.raises(AssertionError) as info:
         testing.assert_frames_equal(actual, expected)
 
-    assert info.value.message == "Expected row 0 not found."
+    assert str(info.value) == "Expected row 0 not found."
 
 
 def test_frames_equal_mismatched_items():
@@ -40,7 +40,7 @@ def test_frames_equal_mismatched_items():
     with pytest.raises(AssertionError) as info:
         testing.assert_frames_equal(actual, expected)
 
-    assert info.value.message == """
+    assert str(info.value) == """
 Items are not equal:
  ACTUAL: 2
  DESIRED: 1

--- a/urbansim/utils/tests/test_yamlio.py
+++ b/urbansim/utils/tests/test_yamlio.py
@@ -1,6 +1,9 @@
 import os
 import tempfile
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import numpy as np
 import pandas as pd

--- a/urbansim/utils/yamlio.py
+++ b/urbansim/utils/yamlio.py
@@ -2,7 +2,10 @@
 Utilities for doing IO to YAML files.
 
 """
-import itertools
+try:
+    from itertools import izip as zip
+except ImportError:
+    pass
 import os
 import numpy as np
 
@@ -26,7 +29,7 @@ def series_to_yaml_safe(series):
     index = series.index.to_native_types(quoting=True)
     values = series.values.tolist()
 
-    return {i: v for i, v in itertools.izip(index, values)}
+    return {i: v for i, v in zip(index, values)}
 
 
 def frame_to_yaml_safe(frame):

--- a/urbansim/utils/yamlio.py
+++ b/urbansim/utils/yamlio.py
@@ -56,7 +56,7 @@ def to_scalar_safe(obj):
     """
     try:
         return np.asscalar(obj)
-    except:
+    except Exception:
         return obj
 
 


### PR DESCRIPTION
This PR includes many changes to make UrbanSim compatible with both Python 2.7 and 3.X. Changes include (in order of importance):

* Added future import of true division and forced floor division in a few places where it seemed necessary, mostly `mnl.py` and `pmat.py`. @fscottfoti it would be great if you wouldn't mind taking a look at these (I added TODOs in the important spots).
* Changes to iterators like `dict.iteritems()` and `itertools.izip()` which were removed in Python 3. I replaced iteritems with `dict.items()` which is inefficient in Python 2 since it doesn't use a generator, but most use cases are very simple so it shouldn't make a different in performance.
* Convert implicit relative imports to explicit relative imports where appropriate.
* Error message strings in the `e.message` format converted to `str(e)`.
* Updated imports to reflect changes to standard library.
* Some tests for functions that use Python sets were failing due to reordered items; tests were changed to sort results before assertions.
* Some tests were failing in Windows due to int64/int32 mismatch; dtype checking was disabled for these tests.
* Travis CI and Appveyor CI updated to build in both Python 2.7 and 3.5. We'll need to update these once Orca 1.4 is released and sanfran_urbansim's equivalent branch is merged.
* PEP 8 formatting changes (the `pep8` package was dropped in CI builds in favor of the new `pycodestyle`).
* Updated print statements.

I'll leave this PR open for a bit. It'd be great if folks are able to test this on Python 3.X and make sure we aren't missing important edge cases or compatibility issues. 