### PR TITLE
add fidx and tests

### DIFF
--- a/urbansim/utils/misc.py
+++ b/urbansim/utils/misc.py
@@ -192,17 +192,17 @@ def fidx(right, left, left_fk=None):
     Parameters:
     -----------
     right: pandas.DataFrame or pandas.Series
-        Series or set of data frame to re-index from.
+        Series or data frame to re-index from.
     left: pandas.Series or pandas.DataFrame
         Series or data frame to re-index to.
         If a series is provided, its values serve as the foreign keys.
         If a data frame is provided, one or more columns may be used
         as foreign keys, must specify the ``left_fk`` argument to
-        specify which columns will serve as keys.
+        specify which column(s) will serve as keys.
     left_fk: optional, str or list of str
-        Used when the left is a data frame, specifies the columns in
-        the left to serve as foreign keys. The ordering must match
-        the order of the multi-index in the right.
+        Used when the left is a data frame, specifies the column(s) in
+        the left to serve as foreign keys. The specified columns' ordering
+        must match the order of the multi-index in the right.
 
     Returns:
     --------


### PR DESCRIPTION
This PR adds a new method for re-indexing a series or data frame based on a foreign key relationship, called **_fidx_**. This is is similar to  _utils.misc.reindex_. The key differences are

1) This method can re-index both series and data frames.

2) The method can re-index using mutliple-columns on the left, this implies that the right has a multi-index. This is helpful when doing an aggregation across multiple columns and then joining the result back to the original data frame.

For example, suppose we want to assign to each household the number of households of the same building type in their zone:

```python
hh_by_zone_type = h.groupby(['zone', 'building_type_id']).size()
h['zonal_hh_same_type'] = fidx(hh_by_zone_type, h, ['zone', 'building_type_id'])
``` 

See the tests for examples.
