### PR TITLE
allow ordered dict export to yaml

### DIFF
--- a/urbansim/utils/tests/test_yamlio.py
+++ b/urbansim/utils/tests/test_yamlio.py
@@ -149,7 +149,7 @@ def test_frame_to_yaml_safe():
     assert_dfs_equal(pd.DataFrame(yaml.load(y)), df)
 
 
-def test_orderered_dict():
+def test_ordered_dict():
 
     inner_dict = OrderedDict()
     inner_dict['z'] = 'had'

--- a/urbansim/utils/tests/test_yamlio.py
+++ b/urbansim/utils/tests/test_yamlio.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 import yaml
 from pandas.util import testing as pdt
+from collections import OrderedDict
 
 from .. import yamlio
 
@@ -146,3 +147,19 @@ def test_frame_to_yaml_safe():
                  'col2': {0: 'a', 1: 'b', 2: 'c'}}
     y = yaml.dump(d, default_flow_style=False)
     assert_dfs_equal(pd.DataFrame(yaml.load(y)), df)
+
+
+def test_orderered_dict_out():
+
+    inner_dict = OrderedDict()
+    inner_dict['z'] = 'had'
+    inner_dict['a'] = 'a'
+    inner_dict['f'] = 'little'
+
+    outer_dict = OrderedDict()
+    outer_dict[10] = 'marry'
+    outer_dict['inner'] = inner_dict
+    outer_dict['a'] = 'lamb'
+
+    expected = '10: marry\n\ninner:\n    z: had\n    a: a\n    f: little\n\na: lamb\n'
+    assert expected == yamlio.convert_to_yaml(outer_dict, None)

--- a/urbansim/utils/tests/test_yamlio.py
+++ b/urbansim/utils/tests/test_yamlio.py
@@ -149,7 +149,7 @@ def test_frame_to_yaml_safe():
     assert_dfs_equal(pd.DataFrame(yaml.load(y)), df)
 
 
-def test_orderered_dict_out():
+def test_orderered_dict():
 
     inner_dict = OrderedDict()
     inner_dict['z'] = 'had'
@@ -161,5 +161,39 @@ def test_orderered_dict_out():
     outer_dict['inner'] = inner_dict
     outer_dict['a'] = 'lamb'
 
-    expected = '10: marry\n\ninner:\n    z: had\n    a: a\n    f: little\n\na: lamb\n'
-    assert expected == yamlio.convert_to_yaml(outer_dict, None)
+    y = yamlio.convert_to_yaml(outer_dict, None)
+    d = yamlio.yaml_to_dict(y, ordered=True)
+    assert outer_dict == d
+
+
+def test_ordered_series_to_yaml_safe():
+
+    s = pd.Series(np.arange(3), index=list('zxy'))
+
+    od = yamlio.series_to_yaml_safe(s, True)
+    y = yamlio.convert_to_yaml(od, None)
+    new_od = yamlio.yaml_to_dict(y, ordered=True)
+    new_s = pd.Series(new_od)
+    assert_series_equal(s, new_s)
+
+
+def test_ordered_frame_to_yaml_safe():
+
+    # data frame to test with
+    df = pd.DataFrame(
+        OrderedDict([
+            ('z', np.arange(0, 5)),
+            ('y', np.arange(5, 10)),
+            ('x', list('abcde'))
+        ]),
+        index=pd.Index(np.arange(20, 15, -1))
+    )
+
+    # send to yaml
+    od = yamlio.frame_to_yaml_safe(df, True)
+    y = yamlio.convert_to_yaml(od, None)
+
+    # load from yaml
+    new_od = yamlio.yaml_to_dict(y, ordered=True)
+    new_df = pd.DataFrame.from_dict(new_od, orient='index').reindex(new_od.keys()).T
+    assert_dfs_equal(df, new_df)

--- a/urbansim/utils/yamlio.py
+++ b/urbansim/utils/yamlio.py
@@ -7,23 +7,25 @@ try:
 except ImportError:
     pass
 import os
+import sys
 import numpy as np
 
 import yaml
 from collections import OrderedDict
 
 
-def represent_long(dumper, data):
-    """
-    Strips away extraneous long format text.
+if sys.version_info < 3:
 
-    e.g. !!python/long '14' will be formatted as 14
+    def represent_long(dumper, data):
+        """
+        Strips away extraneous long format text.
 
-    """
-    return dumper.represent_int(data)
+        e.g. !!python/long '14' will be formatted as 14
 
+        """
+        return dumper.represent_int(data)
 
-yaml.add_representer(long, represent_long)
+    yaml.add_representer(long, represent_long)
 
 
 def series_to_yaml_safe(series, ordered=False):

--- a/urbansim/utils/yamlio.py
+++ b/urbansim/utils/yamlio.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 
 if sys.version_info[0] < 3:
 
-    def represent_long(dumper, data):
+    def __represent_long(dumper, data):
         """
         Strips away extraneous long format text. Only applicable
         for py27.
@@ -26,7 +26,7 @@ if sys.version_info[0] < 3:
         """
         return dumper.represent_int(data)
 
-    yaml.add_representer(long, represent_long)
+    yaml.add_representer(long, __represent_long)
 
 
 def series_to_yaml_safe(series, ordered=False):
@@ -63,10 +63,12 @@ def frame_to_yaml_safe(frame, ordered=False):
     Parameters
     ----------
     frame : pandas.DataFrame
+    ordered: bool, optional, default False
+        If True, an OrderedDict is returned.
 
     Returns
     -------
-    safe : dict
+    safe : dict or OrderedDict
 
     """
     if ordered:
@@ -132,7 +134,7 @@ def ordered_yaml(cfg, order=None):
     return '\n'.join(s)
 
 
-def represent_ordereddict(dumper, data):
+def __represent_ordereddict(dumper, data):
     """
     Allows for OrderedDict to be written out to yaml.
 
@@ -152,7 +154,7 @@ def represent_ordereddict(dumper, data):
     return yaml.nodes.MappingNode(u'tag:yaml.org,2002:map', value)
 
 
-yaml.add_representer(OrderedDict, represent_ordereddict)
+yaml.add_representer(OrderedDict, __represent_ordereddict)
 
 
 def convert_to_yaml(cfg, str_or_buffer):
@@ -202,6 +204,8 @@ def yaml_to_dict(yaml_str=None, str_or_buffer=None, ordered=False):
         A string of YAML.
     str_or_buffer : str or file like, optional
         File name or buffer from which to load YAML.
+    ordered: bool, optional, default False
+        If True, an OrderedDict is returned.
 
     Returns
     -------
@@ -214,7 +218,7 @@ def yaml_to_dict(yaml_str=None, str_or_buffer=None, ordered=False):
 
     # determine which load method to use
     if ordered:
-        loader = ordered_load
+        loader = __ordered_load
     else:
         loader = yaml.load
 
@@ -229,7 +233,7 @@ def yaml_to_dict(yaml_str=None, str_or_buffer=None, ordered=False):
     return d
 
 
-def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+def __ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
     """
     Loads yaml into an OrderedDict.
 

--- a/urbansim/utils/yamlio.py
+++ b/urbansim/utils/yamlio.py
@@ -14,11 +14,12 @@ import yaml
 from collections import OrderedDict
 
 
-if sys.version_info < 3:
+if sys.version_info[0] < 3:
 
     def represent_long(dumper, data):
         """
-        Strips away extraneous long format text.
+        Strips away extraneous long format text. Only applicable
+        for py27.
 
         e.g. !!python/long '14' will be formatted as 14
 


### PR DESCRIPTION
Currently, in _utils.yamlio_, dictionaries exported via _convert_to_yaml_ use a hard-coded list to control the ordering of keys in the output file. This has two drawbacks (1) the list has to be updated when new parameters are added and (2) only the outer dictionaries ordering can be controlled, the ordering of inner dictionaries will not follow the order list. 

This PR adds support for exporting ordered dictionaries to yaml in _utils.yamlio_.  For example, the following: 

```python
inner_dict = OrderedDict()
inner_dict['z'] = 'had'
inner_dict['a'] = 'a'
inner_dict['f'] = 'little'

outer_dict = OrderedDict()
outer_dict[10] = 'marry'
outer_dict['inner'] = inner_dict
outer_dict['a'] = 'lamb'

yamlio.convert_to_yaml(outer_dict, my_file.yaml)
```

Will have the following yaml:

```yaml
10: marry

inner:
    z: had
    a: a
    f: little

a: lamb

```

Note that if a ordered dictionary is provided (as in the current example), its ordering will override the hard-code ordering the yamlio file.