### PR TITLE
Fixing pandana version to 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
         'zbox>=1.2'
     ],
     extras_require={
-        'pandana': ['pandana>=0.1']
+        'pandana': ['pandana==0.3.0']
     }
 )


### PR DESCRIPTION
If the latest version is used, we can end up with v0.4.0 that seems to
have issues with Travis.