### PR TITLE
check for accounting column when throwing "Number of rows" error in r…

### DIFF
--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -94,8 +94,13 @@ def remove_rows(data, nrows, accounting_column=None):
     unit_check = data[accounting_column].sum() if accounting_column else len(data)
     if nrows == 0:
         return data, _empty_index()
-    elif nrows > unit_check:
-        raise ValueError('Number of rows to remove exceeds number of records in table.')
+
+    if accounting_column:
+        if nrows > data[accounting_column].sum():
+            raise ValueError('Number of rows to remove exceeds number of rows in table.')
+    else:
+        if nrows > len(data):
+            raise ValueError('Number of rows to remove exceeds number of rows in table.')
 
     remove_rows = sample_rows(nrows, data, accounting_column=accounting_column, replace=False)
     remove_index = remove_rows.index


### PR DESCRIPTION
The remove_rows method in transition.py checks if the rows to remove greater than current number of rows, and throws an error if this test fails. When using accounting columns, the parameter nrows does not represent the number of rows to remove, but difference in value in the accounting column. Therefore the test must first check if accounting column exists, and if it does check if if `nrows > data[accounting_column].sum()`