### PR TITLE
Fixes slicing of feasibility table in keep_form_with_max_profit() in Developer.py

### DIFF
--- a/urbansim/developer/developer.py
+++ b/urbansim/developer/developer.py
@@ -62,7 +62,13 @@ class Developer(object):
         f = self.feasibility
 
         if forms is not None:
-            f = f[forms]
+            feas = pd.DataFrame(index=f.index,
+                                columns=pd.MultiIndex.from_tuples(f[forms].columns.values))
+
+            for form in forms:
+                feas[form] = f[form].values
+
+            f = feas
 
         if len(f) > 0:
             mu = self._max_form(f, "max_profit")

--- a/urbansim/developer/developer.py
+++ b/urbansim/developer/developer.py
@@ -62,13 +62,8 @@ class Developer(object):
         f = self.feasibility
 
         if forms is not None:
-            feas = pd.DataFrame(index=f.index,
-                                columns=pd.MultiIndex.from_tuples(f[forms].columns.values))
-
-            for form in forms:
-                feas[form] = f[form].values
-
-            f = feas
+            f_index = f[forms].columns.remove_unused_levels()
+            f = pd.DataFrame(data=f[forms], columns=f_index)
 
         if len(f) > 0:
             mu = self._max_form(f, "max_profit")


### PR DESCRIPTION
Developer.pick() allows a list of forms passed to the forms parameter, which will slice the feasibility dataframe to include the forms in the list. When Pandas slices a df with a MultiIndex, it keeps all of the levels from the original df, even if they are not used. Since all the levels remain in MultiIndex of columns the sliced feasibility df, calling stack(level=0) on the sliced df will put forms that we are trying to exclude in the stacked output.

[Refer to the pandas docs] https://pandas.pydata.org/pandas-docs/stable/advanced.html#defined-levels) for more information about Defined Levels in pandas MultiIndex