### PR TITLE
worn in the case of non-convergence

### DIFF
--- a/urbansim/urbanchoice/mnl.py
+++ b/urbansim/urbanchoice/mnl.py
@@ -36,8 +36,7 @@ def mnl_probs(data, beta, numalts):
     utilities.reshape(numalts, utilities.size() // numalts)
 
     # https://stats.stackexchange.com/questions/304758/softmax-overflow
-    if clamp:
-        utilities.mat -= utilities.mat.max(0)
+    utilities = utilities.subtract(utilities.max(0))
 
     exponentiated_utility = utilities.exp(inplace=True)
     if clamp:

--- a/urbansim/urbanchoice/mnl.py
+++ b/urbansim/urbanchoice/mnl.py
@@ -245,6 +245,10 @@ def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(-3, 3),
                                                    approx_grad=False,
                                                    bounds=bounds
                                                    )
+
+    if bfgs_result[2]['warnflag'] > 0:
+        logger.warn("mnl did not converge correctly: %s",  bfgs_result)
+
     beta = bfgs_result[0]
     stderr = mnl_loglik(
         beta, data, chosen, numalts, weights, stderr=1, lcgrad=lcgrad)

--- a/urbansim/urbanchoice/mnl.py
+++ b/urbansim/urbanchoice/mnl.py
@@ -35,6 +35,10 @@ def mnl_probs(data, beta, numalts):
         raise Exception("Number of alternatives is zero")
     utilities.reshape(numalts, utilities.size() // numalts)
 
+    # https://stats.stackexchange.com/questions/304758/softmax-overflow
+    if clamp:
+        utilities.mat -= utilities.mat.max(0)
+
     exponentiated_utility = utilities.exp(inplace=True)
     if clamp:
         exponentiated_utility.inftoval(1e20)

--- a/urbansim/urbanchoice/pmat.py
+++ b/urbansim/urbanchoice/pmat.py
@@ -79,6 +79,12 @@ class PMAT:
         # elif self.typ == 'cuda':
         #  return PMAT(misc.cumsum(self.mat,axis=axis))
 
+    def max(self, axis):
+        if self.typ == 'numpy':
+            return PMAT(np.max(self.mat, axis=axis))
+        elif self.typ == 'cuda':
+            return PMAT(self.mat.max(axis=axis))
+
     def argmax(self, axis):
         if self.typ == 'numpy':
             return PMAT(np.argmax(self.mat, axis=axis))


### PR DESCRIPTION
At yesterday's meeting with @semcogli and @janowicz discuss how deeply **odd** our fitted mnl models wore. Specifically, we have variables that have to be positive that are being fit as negative. In the meeting we considered the possibility of collinearity, or spurious correlations, or bad sampling processes, or other complex possibilities. After the meating I thought that the simplest explanation would be if the optimization algorithm had not successfully `fitted` the models in the first place. 

Looking at the code I see that we did not check it `optimize.fmin_l_bfgs_b` had succeeded. So I added a warning that reports some diagnostic information in case of non-convergence. 

When I ran the tests I noted that `test_alternative_specific_coeffs` reliably thru a non-convergence warning `'ABNORMAL_TERMINATION_IN_LNSRCH'`. According to the internet, that diagnostic code is usually caused by programer error. I also noted the `RuntimeWarning: overflow encountered in exp`. After some research I found a standard technique for avoiding overflow in softmax calculations, applying it solved both warnings. The resulting output did not otherwise change.

TLDR:

- Warn if we may be returning incorrect output.
- Fix a numerical instability / Overflow.
- No evidence that it solves any of the bigger problems.