### PR TITLE
Resolve yaml.load() deprecations

### DIFF
--- a/urbansim/models/tests/test_dcm.py
+++ b/urbansim/models/tests/test_dcm.py
@@ -222,10 +222,10 @@ def test_mnl_dcm_yaml(basic_dcm, choosers, alternatives):
         'fit_parameters': None
     }
 
-    assert yaml.load(basic_dcm.to_yaml()) == expected_dict
+    assert yaml.safe_load(basic_dcm.to_yaml()) == expected_dict
 
     new_mod = dcm.MNLDiscreteChoiceModel.from_yaml(basic_dcm.to_yaml())
-    assert yaml.load(new_mod.to_yaml()) == expected_dict
+    assert yaml.safe_load(new_mod.to_yaml()) == expected_dict
 
     basic_dcm.fit(choosers, alternatives, 'thing_id')
 
@@ -233,7 +233,7 @@ def test_mnl_dcm_yaml(basic_dcm, choosers, alternatives):
     del expected_dict['log_likelihoods']
     del expected_dict['fit_parameters']
 
-    actual_dict = yaml.load(basic_dcm.to_yaml())
+    actual_dict = yaml.safe_load(basic_dcm.to_yaml())
     assert isinstance(actual_dict.pop('log_likelihoods'), dict)
     assert isinstance(actual_dict.pop('fit_parameters'), dict)
 
@@ -524,10 +524,10 @@ def test_mnl_dcm_segmented_yaml(grouped_choosers, alternatives):
         }
     }
 
-    assert yaml.load(group.to_yaml()) == expected_dict
+    assert yaml.safe_load(group.to_yaml()) == expected_dict
 
     new_seg = dcm.SegmentedMNLDiscreteChoiceModel.from_yaml(group.to_yaml())
-    assert yaml.load(new_seg.to_yaml()) == expected_dict
+    assert yaml.safe_load(new_seg.to_yaml()) == expected_dict
 
     group.fit(grouped_choosers, alternatives, 'thing_id')
 
@@ -539,7 +539,7 @@ def test_mnl_dcm_segmented_yaml(grouped_choosers, alternatives):
     del expected_dict['models']['y']['fit_parameters']
     del expected_dict['models']['y']['log_likelihoods']
 
-    actual_dict = yaml.load(group.to_yaml())
+    actual_dict = yaml.safe_load(group.to_yaml())
     assert isinstance(actual_dict['models']['x'].pop('fit_parameters'), dict)
     assert isinstance(actual_dict['models']['x'].pop('log_likelihoods'), dict)
     assert isinstance(actual_dict['models']['y'].pop('fit_parameters'), dict)

--- a/urbansim/models/tests/test_regression.py
+++ b/urbansim/models/tests/test_regression.py
@@ -211,7 +211,7 @@ class TestRegressionModelYAMLNotFit(object):
 
     def test_string(self):
         test_yaml = self.model.to_yaml()
-        assert_dict_specs_equal(yaml.load(test_yaml), self.expected_dict)
+        assert_dict_specs_equal(yaml.safe_load(test_yaml), self.expected_dict)
 
         model = regression.RegressionModel.from_yaml(yaml_str=test_yaml)
         assert isinstance(model, regression.RegressionModel)
@@ -220,7 +220,7 @@ class TestRegressionModelYAMLNotFit(object):
         test_buffer = StringIO()
         self.model.to_yaml(str_or_buffer=test_buffer)
         assert_dict_specs_equal(
-            yaml.load(test_buffer.getvalue()), self.expected_dict)
+            yaml.safe_load(test_buffer.getvalue()), self.expected_dict)
 
         test_buffer.seek(0)
         model = regression.RegressionModel.from_yaml(str_or_buffer=test_buffer)
@@ -233,7 +233,7 @@ class TestRegressionModelYAMLNotFit(object):
         self.model.to_yaml(str_or_buffer=test_file)
 
         with open(test_file) as f:
-            assert_dict_specs_equal(yaml.load(f), self.expected_dict)
+            assert_dict_specs_equal(yaml.safe_load(f), self.expected_dict)
 
         model = regression.RegressionModel.from_yaml(str_or_buffer=test_file)
         assert isinstance(model, regression.RegressionModel)
@@ -375,10 +375,10 @@ def test_SegmentedRegressionModel_yaml(groupby_df):
         }
     }
 
-    assert yaml.load(seg.to_yaml()) == expected_dict
+    assert yaml.safe_load(seg.to_yaml()) == expected_dict
 
     new_seg = regression.SegmentedRegressionModel.from_yaml(seg.to_yaml())
-    assert yaml.load(new_seg.to_yaml()) == expected_dict
+    assert yaml.safe_load(new_seg.to_yaml()) == expected_dict
 
     seg.fit(groupby_df)
 
@@ -392,7 +392,7 @@ def test_SegmentedRegressionModel_yaml(groupby_df):
     del expected_dict['models']['y']['fit_rsquared']
     del expected_dict['models']['y']['fit_rsquared_adj']
 
-    actual_dict = yaml.load(seg.to_yaml())
+    actual_dict = yaml.safe_load(seg.to_yaml())
     assert isinstance(actual_dict['models']['x'].pop('fit_parameters'), dict)
     assert isinstance(actual_dict['models']['x'].pop('fit_rsquared'), float)
     assert isinstance(

--- a/urbansim/utils/networks.py
+++ b/urbansim/utils/networks.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def from_yaml(net, cfgname):
     print("Computing accessibility variables")
-    cfg = yaml.load(open(misc.config(cfgname)))
+    cfg = yaml.safe_load(open(misc.config(cfgname)))
 
     nodes = pd.DataFrame(index=net.node_ids)
 

--- a/urbansim/utils/tests/test_yamlio.py
+++ b/urbansim/utils/tests/test_yamlio.py
@@ -123,7 +123,7 @@ def test_series_to_yaml_safe_int_index():
 
     assert d == {0: 100, 1: 101, 2: 102}
     y = yaml.dump(d, default_flow_style=False)
-    assert_series_equal(pd.Series(yaml.load(y)), s)
+    assert_series_equal(pd.Series(yaml.safe_load(y)), s)
 
 
 def test_series_to_yaml_safe_str_index():
@@ -133,7 +133,7 @@ def test_series_to_yaml_safe_str_index():
 
     assert d == {'x': 'a', 'y': 'b', 'z': 'c'}
     y = yaml.dump(d, default_flow_style=False)
-    assert_series_equal(pd.Series(yaml.load(y)), s)
+    assert_series_equal(pd.Series(yaml.safe_load(y)), s)
 
 
 def test_frame_to_yaml_safe():
@@ -146,7 +146,7 @@ def test_frame_to_yaml_safe():
     assert d == {'col1': {0: 100, 1: 200, 2: 300},
                  'col2': {0: 'a', 1: 'b', 2: 'c'}}
     y = yaml.dump(d, default_flow_style=False)
-    assert_dfs_equal(pd.DataFrame(yaml.load(y)), df)
+    assert_dfs_equal(pd.DataFrame(yaml.safe_load(y)), df)
 
 
 def test_ordered_dict():

--- a/urbansim/utils/yamlio.py
+++ b/urbansim/utils/yamlio.py
@@ -220,7 +220,7 @@ def yaml_to_dict(yaml_str=None, str_or_buffer=None, ordered=False):
     if ordered:
         loader = __ordered_load
     else:
-        loader = yaml.load
+        loader = yaml.safe_load
 
     if yaml_str:
         d = loader(yaml_str)


### PR DESCRIPTION
This PR resolves `yaml.load()` deprecations, as described in issue #216.

### Changes

Replaces all instances of `yaml.load()` with `yaml.safe_load()`, except where a `Loader=...` argument is provided.

### Potential compatibility issues

`yaml.safe_load()` prevents arbitrary Python data types from being encoded and decoded from yaml. Since our use case here is specifically to store dictionary representations of model specifications, I don't see this being an issue. 

See additional discussion in issue #216.