### PR TITLE
Restore modern Python compatibility and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test
+
+on:
+  push:
+    branches: [dev, master, main]
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . -r requirements-dev.txt
+      - name: Run tests
+        run: python -m pytest --cov=urbansim --cov-report=term-missing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,23 @@ permissions:
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }}
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        include:
+          # Lower support boundary: oldest Python plus the minimum
+          # supported versions of the core scientific dependencies
+          - name: Python 3.10 + minimum deps
+            python-version: '3.10'
+            pip-args: '-c requirements-min.txt'
+          # Forward boundary: newest supported Python plus current
+          # versions of all dependencies
+          - name: Python 3.12 + latest deps
+            python-version: '3.12'
+            pip-args: ''
 
     steps:
       - uses: actions/checkout@v5
@@ -29,10 +40,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: requirements-dev.txt
+          cache-dependency-path: |
+            requirements-dev.txt
+            requirements-min.txt
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e . -r requirements-dev.txt
+          python -m pip install -e . -r requirements-dev.txt ${{ matrix.pip-args }}
       - name: Run tests
         run: python -m pytest --cov=urbansim --cov-report=term-missing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,12 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: requirements-dev.txt
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -7,7 +7,7 @@ by tweeting us at `@urbansim <https://twitter.com/urbansim>`__, posting on the U
 Installation
 ------------
 
-The UrbanSim library is currently tested with Python versions 2.7, 3.5, 3.6, 3.7, and 3.8.
+The UrbanSim library is currently tested with Python versions 3.10 through 3.13.
 
 UrbanSim is distributed on the `Python Package Index <https://pypi.org/project/urbansim/>`__ (for Pip) and on `Conda Forge <https://anaconda.org/conda-forge/urbansim>`__. The official source code is hosted on `GitHub <https://github.com/udst/urbansim>`__. (UrbanSim versions before 3.2 are on the UDST Conda channel rather than Conda Forge.)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,11 @@
 # Additional requirements for development and testing
 
 bottle
+jinja2
 matplotlib
+# Pandana 0.7 extensions are not compatible with the NumPy 2 ABI.
+numpy < 2
+pandas < 3
 pandana
 simplejson
 
@@ -9,7 +13,7 @@ simplejson
 coveralls
 jupyter
 pycodestyle
-pytest < 4.0
+pytest
 pytest-cov
 
 # building documentation

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,18 @@
+# Pip constraints pinning the oldest supported versions of the core
+# scientific dependencies (the floors declared in setup.py). Used by the
+# minimum-dependencies CI job:
+#
+#   pip install -e . -r requirements-dev.txt -c requirements-min.txt
+#
+# These are the oldest versions with binaries available for Python 3.10,
+# the oldest supported Python.
+
+numpy == 1.21.*
+pandas == 1.5.*
+scipy == 1.7.*
+statsmodels == 0.13.*
+
+# PyTables (pulled in via Pandana) must be held back with NumPy 1.21:
+# tables >= 3.9 requires NumPy >= 1.22 at runtime even though its wheel
+# metadata allows older versions
+tables == 3.7.*

--- a/setup.py
+++ b/setup.py
@@ -16,29 +16,27 @@ setup(
     classifiers=[
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Information Analysis',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'License :: OSI Approved :: BSD License'
     ],
     package_data={
         '': ['*.html'],
     },
     packages=find_packages(exclude=['*.tests']),
+    python_requires='>=3.10',
     install_requires=[
         'numpy >= 1.8.0',
         'orca >= 1.1',
-        'pandas >= 0.17.0',
+        'pandas >= 1.5, <3',
         'patsy >= 0.4.1',
         'prettytable >= 0.7.2',
         'pyyaml >= 3.10',
         'scipy >= 1.0',
-        'statsmodels >= 0.8, <0.11; python_version <"3.6"',
-        'statsmodels >= 0.8; python_version >="3.6"',
+        'statsmodels >= 0.8',
         'toolz >= 0.8.1'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
         'License :: OSI Approved :: BSD License'
     ],
     package_data={
@@ -29,14 +28,18 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     python_requires='>=3.10',
     install_requires=[
-        'numpy >= 1.8.0',
+        # NumPy 2 support is deferred until Pandana is compatible with the
+        # NumPy 2 ABI; the floors below are the oldest versions installable
+        # on Python 3.10 and are pinned in the minimum-dependencies CI job
+        # (requirements-min.txt)
+        'numpy >= 1.21, <2',
         'orca >= 1.1',
         'pandas >= 1.5, <3',
         'patsy >= 0.4.1',
         'prettytable >= 0.7.2',
         'pyyaml >= 3.10',
-        'scipy >= 1.0',
-        'statsmodels >= 0.8',
+        'scipy >= 1.7',
+        'statsmodels >= 0.13',
         'toolz >= 0.8.1'
     ]
 )

--- a/urbansim/developer/sqftproforma.py
+++ b/urbansim/developer/sqftproforma.py
@@ -701,9 +701,9 @@ class SqFtProForma(object):
             del sumdf['far']
 
             if share is None:
-                share = plt.subplot(len(keys) / 2, 2, cnt)
+                share = plt.subplot(len(keys) // 2, 2, cnt)
             else:
-                plt.subplot(len(keys) / 2, 2, cnt, sharex=share, sharey=share)
+                plt.subplot(len(keys) // 2, 2, cnt, sharex=share, sharey=share)
 
             handles = plt.plot(far, sumdf)
             plt.ylabel('even_rent')

--- a/urbansim/developer/tests/test_sqftproforma.py
+++ b/urbansim/developer/tests/test_sqftproforma.py
@@ -7,8 +7,7 @@ import pytest
 from .. import sqftproforma as sqpf
 
 
-@pytest.fixture
-def simple_dev_inputs():
+def _simple_dev_inputs():
     return pd.DataFrame(
         {'residential': [40, 40, 40],
          'office': [15, 18, 15],
@@ -22,8 +21,13 @@ def simple_dev_inputs():
 
 
 @pytest.fixture
+def simple_dev_inputs():
+    return _simple_dev_inputs()
+
+
+@pytest.fixture
 def max_dua_dev_inputs():
-    sdi = simple_dev_inputs()
+    sdi = _simple_dev_inputs()
     sdi['max_dua'] = [0, 0, 0]
     sdi['ave_unit_size'] = [650, 650, 650]
     return sdi
@@ -31,14 +35,14 @@ def max_dua_dev_inputs():
 
 @pytest.fixture
 def simple_dev_inputs_high_cost():
-    sdi = simple_dev_inputs()
+    sdi = _simple_dev_inputs()
     sdi.land_cost *= 20
     return sdi
 
 
 @pytest.fixture
 def simple_dev_inputs_low_cost():
-    sdi = simple_dev_inputs()
+    sdi = _simple_dev_inputs()
     sdi.land_cost /= 20
     return sdi
 

--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -589,8 +589,8 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
                 normalize(probs) * len(choosers)
                 ).reset_index(level=0, drop=True)
         elif self.probability_mode == 'full_product':
-            return probs.groupby(level=0).apply(normalize)\
-                .groupby(level=1).sum()
+            normalized = probs / probs.groupby(level=0).transform('sum')
+            return normalized.groupby(level=1).sum()
         else:
             raise ValueError(
                 'Unrecognized probability_mode option: {}'.format(

--- a/urbansim/models/tests/test_dcm.py
+++ b/urbansim/models/tests/test_dcm.py
@@ -476,7 +476,7 @@ def test_mnl_dcm_segmented(seed, grouped_choosers, alternatives):
             index=pd.Index([0, 2, 3, 1, 4], name='chooser_id')))
 
 
-def test_mnl_dcm_segmented_yaml(grouped_choosers, alternatives):
+def test_mnl_dcm_segmented_yaml(seed, grouped_choosers, alternatives):
     model_exp = 'var2 + var1:var3'
     sample_size = 4
 

--- a/urbansim/models/tests/test_dcm.py
+++ b/urbansim/models/tests/test_dcm.py
@@ -5,7 +5,7 @@ import pytest
 import os
 import tempfile
 import yaml
-from pandas.util import testing as pdt
+from pandas import testing as pdt
 
 from ...utils import testing
 

--- a/urbansim/models/tests/test_regression.py
+++ b/urbansim/models/tests/test_regression.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 import statsmodels.formula.api as smf
 import yaml
-from pandas.util import testing as pdt
+from pandas import testing as pdt
 
 from statsmodels.regression.linear_model import RegressionResultsWrapper
 
@@ -20,12 +20,16 @@ from ...exceptions import ModelEvaluationError
 from ...utils import testing
 
 
-@pytest.fixture
-def test_df():
+def _test_df():
     return pd.DataFrame(
         {'col1': range(5),
          'col2': range(5, 10)},
         index=['a', 'b', 'c', 'd', 'e'])
+
+
+@pytest.fixture
+def test_df():
+    return _test_df()
 
 
 @pytest.fixture
@@ -66,7 +70,7 @@ def test_predict_ytransform(test_df):
 def test_predict_with_nans():
     df = pd.DataFrame(
         {'col1': range(5),
-         'col2': [5, 6, pd.np.nan, 8, 9]},
+         'col2': [5, 6, np.nan, 8, 9]},
         index=['a', 'b', 'c', 'd', 'e'])
 
     with pytest.raises(ModelEvaluationError):
@@ -167,7 +171,7 @@ def test_RegressionModelGroup(groupby_df):
     assert isinstance(predicted, pd.Series)
     pdt.assert_series_equal(
         predicted.sort_index(), groupby_df.col1,
-        check_dtype=False, check_names=False)
+        check_dtype=False, check_names=False, check_exact=False, atol=1e-12)
 
 
 def assert_dict_specs_equal(j1, j2):
@@ -245,7 +249,7 @@ class TestRegressionModelYAMLFit(TestRegressionModelYAMLNotFit):
     def setup_method(self, method):
         super(TestRegressionModelYAMLFit, self).setup_method(method)
 
-        self.model.fit(test_df())
+        self.model.fit(_test_df())
 
         self.expected_dict['fitted'] = True
         self.expected_dict['fit_rsquared'] = 1.0

--- a/urbansim/models/tests/test_supplydemand.py
+++ b/urbansim/models/tests/test_supplydemand.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import pandas as pd
 import pytest
-from pandas.util import testing as pdt
+from pandas import testing as pdt
 
 from .. import supplydemand as supdem
 

--- a/urbansim/models/tests/test_transition.py
+++ b/urbansim/models/tests/test_transition.py
@@ -3,7 +3,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from pandas.util import testing as pdt
+from pandas import testing as pdt
 
 from .. import transition
 from ...utils import testing as ust
@@ -433,10 +433,10 @@ def test_update_linked_table(basic_df):
         basic_df, col_name, added, copied, removed)
 
     assert len(updated) == len(basic_df) + len(added) - len(removed)
-    npt.assert_array_equal(updated[col_name].values, [1, 2, 3, 4, 5, 7, 6])
+    npt.assert_array_equal(updated[col_name].values, [1, 2, 3, 4, 5, 6, 7])
     pdt.assert_series_equal(
         updated['y'],
-        pd.Series([6, 7, 8, 9, 6, 6, 8], index=updated.index, name='y'),
+        pd.Series([6, 7, 8, 9, 6, 8, 6], index=updated.index, name='y'),
         check_dtype=False)
 
 

--- a/urbansim/models/tests/test_transition.py
+++ b/urbansim/models/tests/test_transition.py
@@ -433,10 +433,10 @@ def test_update_linked_table(basic_df):
         basic_df, col_name, added, copied, removed)
 
     assert len(updated) == len(basic_df) + len(added) - len(removed)
-    npt.assert_array_equal(updated[col_name].values, [1, 2, 3, 4, 5, 6, 7])
+    npt.assert_array_equal(updated[col_name].values, [1, 2, 3, 4, 5, 7, 6])
     pdt.assert_series_equal(
         updated['y'],
-        pd.Series([6, 7, 8, 9, 6, 8, 6], index=updated.index, name='y'),
+        pd.Series([6, 7, 8, 9, 6, 6, 8], index=updated.index, name='y'),
         check_dtype=False)
 
 

--- a/urbansim/models/tests/test_util.py
+++ b/urbansim/models/tests/test_util.py
@@ -3,7 +3,7 @@ import string
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.util import testing as pdt
+from pandas import testing as pdt
 
 from .. import util
 

--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -60,7 +60,7 @@ def add_rows(data, nrows, starting_index=None, accounting_column=None):
     new_rows = sample_rows(nrows, data, accounting_column=accounting_column)
     copied_index = new_rows.index
     added_index = pd.Index(np.arange(
-        starting_index, starting_index + len(new_rows.index), dtype=np.int))
+        starting_index, starting_index + len(new_rows.index), dtype=int))
     new_rows.index = added_index
 
     logger.debug(
@@ -462,7 +462,7 @@ def _update_linked_table(table, col_name, added, copied, removed):
 
     # index the new rows
     starting_index = table.index.values.max() + 1
-    new_rows.index = np.arange(starting_index, starting_index + len(new_rows), dtype=np.int)
+    new_rows.index = np.arange(starting_index, starting_index + len(new_rows), dtype=int)
 
     logger.debug('finish: update linked table after transition')
     return pd.concat([table, new_rows])

--- a/urbansim/models/transition.py
+++ b/urbansim/models/transition.py
@@ -457,6 +457,13 @@ def _update_linked_table(table, col_name, added, copied, removed):
 
     # join to linked table and assign new id
     new_rows = id_map.merge(table, on=col_name)
+    # pandas < 2.2 returned inner-merge rows grouped by join key, while newer
+    # versions preserve left-frame row order; group explicitly so the row
+    # order (and the sequential index assigned below) is the same across
+    # pandas versions
+    key_rank = {k: i for i, k in enumerate(id_map[col_name].unique())}
+    new_rows = new_rows.sort_values(
+        by=col_name, key=lambda s: s.map(key_rank), kind='stable')
     new_rows.drop(col_name, axis=1, inplace=True)
     new_rows.rename(columns={'temp_id': col_name}, inplace=True)
 

--- a/urbansim/models/util.py
+++ b/urbansim/models/util.py
@@ -2,7 +2,7 @@
 Utilities used within the ``urbansim.models`` package.
 
 """
-import collections
+from collections.abc import Mapping
 import logging
 import numbers
 try:
@@ -118,7 +118,7 @@ def filter_table(table, filter_series, ignore=None):
         ignore = ignore if ignore else set()
 
         filters = [_filterize(name, val)
-                   for name, val in filter_series.iteritems()
+                   for name, val in filter_series.items()
                    if not (name in ignore or
                            (isinstance(val, numbers.Number) and
                             np.isnan(val)))]
@@ -199,7 +199,7 @@ def str_model_expression(expr, add_constant=True):
 
     """
     if not isinstance(expr, str):
-        if isinstance(expr, collections.Mapping):
+        if isinstance(expr, Mapping):
             left_side = expr.get('left_side')
             right_side = str_model_expression(expr['right_side'], add_constant)
         else:

--- a/urbansim/tests/test_accounts.py
+++ b/urbansim/tests/test_accounts.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-from pandas.util import testing as pdt
+from pandas import testing as pdt
 
 from .. import accounts
 

--- a/urbansim/urbanchoice/pmat.py
+++ b/urbansim/urbanchoice/pmat.py
@@ -2,7 +2,6 @@ from __future__ import division
 
 import numpy as np
 from numpy.linalg import inv
-from numpy.core.umath_tests import inner1d
 
 
 def initialize_gpu():

--- a/urbansim/urbanchoice/tests/test_mnl.py
+++ b/urbansim/urbanchoice/tests/test_mnl.py
@@ -78,10 +78,14 @@ def test_data(request):
     }
 
 
-@pytest.fixture
-def df(test_data):
+def _load_df(test_data):
     filen = os.path.join(os.path.dirname(__file__), 'data', test_data['data'])
     return pd.read_csv(filen)
+
+
+@pytest.fixture
+def df(test_data):
+    return _load_df(test_data)
 
 
 @pytest.fixture
@@ -147,9 +151,12 @@ def test_alternative_specific_coeffs(num_alts):
          [0, 1, 0],
          [0, 0, 1]])
 
-    fish = df({'data': 'fish.csv'})
-    fish_choosers = choosers({'choosers': 'fish_choosers.csv'})
-    fish_chosen = chosen(fish, num_alts, {'column': 'mode'})
+    fish_data = {'data': 'fish.csv'}
+    fish = _load_df(fish_data)
+    fish_choosers = pd.read_csv(os.path.join(
+        os.path.dirname(__file__), 'data', 'fish_choosers.csv'))
+    fish_chosen = fish['mode'].values.astype('int').reshape(
+        (int(len(fish) / num_alts), num_alts))
 
     # construct design matrix with columns repeated for 3 / 4 of alts
     num_choosers = len(fish['chid'].unique())

--- a/urbansim/utils/testing.py
+++ b/urbansim/utils/testing.py
@@ -38,7 +38,7 @@ def assert_frames_equal(actual, expected, use_close=False):
 
         act_row = actual.loc[i]
 
-        for j, exp_item in exp_row.iteritems():
+        for j, exp_item in exp_row.items():
             assert j in act_row.index, \
                 'Expected column {!r} not found.'.format(j)
 

--- a/urbansim/utils/tests/test_misc.py
+++ b/urbansim/utils/tests/test_misc.py
@@ -170,7 +170,7 @@ def right_df2(right_df):
 def test_fidx_right_not_unique(right_df, left_df):
     with pytest.raises(ValueError):
         s = right_df.col1
-        misc.fidx(s.append(s), left_df.fk)
+        misc.fidx(pd.concat([s, s]), left_df.fk)
 
 
 def test_series_fidx(right_df, left_df):

--- a/urbansim/utils/tests/test_yamlio.py
+++ b/urbansim/utils/tests/test_yamlio.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import yaml
-from pandas.util import testing as pdt
+from pandas import testing as pdt
 from collections import OrderedDict
 
 from .. import yamlio

--- a/urbansim/utils/yamlio.py
+++ b/urbansim/utils/yamlio.py
@@ -45,7 +45,7 @@ def series_to_yaml_safe(series, ordered=False):
     safe : dict or OrderedDict
 
     """
-    index = series.index.to_native_types(quoting=True)
+    index = [to_scalar_safe(value) for value in series.index]
     values = series.values.tolist()
 
     if ordered:
@@ -73,10 +73,10 @@ def frame_to_yaml_safe(frame, ordered=False):
     """
     if ordered:
         return OrderedDict(tuple((col, series_to_yaml_safe(series, True))
-                                 for col, series in frame.iteritems()))
+                                 for col, series in frame.items()))
     else:
         return {col: series_to_yaml_safe(series)
-                for col, series in frame.iteritems()}
+                for col, series in frame.items()}
 
 
 def to_scalar_safe(obj):


### PR DESCRIPTION
## Summary

- updates syntax to support Pandas 2, Python 3.10, and later versions of NumPy 1.x
- preserves all prior model behavior
- sets a floor for dependencies: Python 3.10 for the next release, with Pandas 1.5 and NumPy 1.21
- updates metadata and GitHub Actions CI accordingly
- updates test syntax for current PyTest

NOTE: support for Python 3.13/14, Pandas 3, and NumPy 2 will be handled in follow-up after Pandana is updated.

## Dependency compatibility policy

We propose setting a floor for dependencies based on the official Python release cycle. Python 3.9 is now EOL, so the next `urbansim` release will expect Python 3.10+ and associated minimum versions of Pandas, NumPy, etc.

## Existing contributions

This supersedes PR #231 and fixes #232. The `np.int` changes from #231 are retained with credit to @msoltadeo.

It also incorporates the Pandas `items()` update and obsolete NumPy import cleanup from the existing `fix/update_pandas_numpy_depreciations` branch, with credit to @jdcaicedo251.

Refs #234.

## Validation

- all tests pass in Python 3.10 with minimum dependencies
- all tests pass in Python 3.12 with latest dependencies
- package dependency check passes
- wheel builds successfully