### PR TITLE
Document transition to main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [dev, master, main]
+    branches: [main]
   pull_request:
-    branches: [dev, master, main]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,9 @@ You can contact Sam Maurer, the lead maintainer, at `maurer@urbansim.com`.
 
 - Make your changes, following the existing styles for code and inline documentation
 
-- Add [tests](https://github.com/UDST/urbansim/tree/master/urbansim/tests) if possible!
+- Add [tests](https://github.com/UDST/urbansim/tree/main/urbansim/tests) if possible!
 
-- Open a pull request to the `UDST/urbansim` dev branch, including a writeup of your changes -- take a look at some of the closed PR's for examples
+- Open a pull request to the `UDST/urbansim` main branch, including a writeup of your changes -- take a look at some of the closed PR's for examples
 
 - Current maintainers will review the code, suggest changes, and hopefully merge it!
 
@@ -51,7 +51,7 @@ You can contact Sam Maurer, the lead maintainer, at `maurer@urbansim.com`.
 
 - Make sure all the tests are passing, and check if updates are needed to `README.md` or to the documentation
 
-- Open a pull request to the master branch to finalize it
+- Open a pull request to the main branch to finalize it
 
 - After merging, tag the release on GitHub and follow the distribution procedures below
 
@@ -78,3 +78,10 @@ You can contact Sam Maurer, the lead maintainer, at `maurer@urbansim.com`.
 - Conda Forge bots usually detect new releases on PyPI and set in motion the appropriate feedstock updates, which a current maintainer will need to approve and merge
 
 - Check https://anaconda.org/conda-forge/urbansim for the new version (may take a few minutes for it to appear)
+
+
+## Branch policy
+
+The `main` branch is the default integration and release branch. All new pull requests should target `main`.
+
+The historical `dev` and `master` branches are retained temporarily for reference and compatibility with existing links. They are deprecated and will not receive new development.

--- a/README.rst
+++ b/README.rst
@@ -5,13 +5,9 @@ UrbanSim
     :target: https://pypi.python.org/pypi/urbansim/
     :alt: Latest Version
 
-.. image:: https://travis-ci.org/UDST/urbansim.svg?branch=master
+.. image:: https://github.com/UDST/urbansim/actions/workflows/test.yml/badge.svg?branch=main
    :alt: Build Status
-   :target: https://travis-ci.org/UDST/urbansim
-
-.. image:: https://coveralls.io/repos/UDST/urbansim/badge.svg?branch=master
-   :alt: Test Coverage
-   :target: https://coveralls.io/r/UDST/urbansim?branch=master
+   :target: https://github.com/UDST/urbansim/actions/workflows/test.yml
 
 UrbanSim is a platform for building statistical models of cities and regions. These models help forecast long-range patterns in real estate development, demographics, and related outcomes, under various policy scenarios.
 

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -7,7 +7,7 @@ by tweeting us at `@urbansim <https://twitter.com/urbansim>`__, posting on the U
 Installation
 ------------
 
-The UrbanSim library is currently tested with Python versions 3.10 through 3.13.
+The UrbanSim library is currently tested with Python versions 3.10 through 3.12.
 
 UrbanSim is distributed on the `Python Package Index <https://pypi.org/project/urbansim/>`__ (for Pip) and on `Conda Forge <https://anaconda.org/conda-forge/urbansim>`__. The official source code is hosted on `GitHub <https://github.com/udst/urbansim>`__. (UrbanSim versions before 3.2 are on the UDST Conda channel rather than Conda Forge.)
 
@@ -52,7 +52,7 @@ Please report any bugs you encounter via `GitHub Issues <https://github.com/UDST
 If you have improvements or new features you would like to see in UrbanSim:
 
 1. Open a feature request via `GitHub Issues <https://github.com/UDST/urbansim/issues>`__.
-2. See our code contribution instructions `here <https://github.com/UDST/urbansim/blob/master/CONTRIBUTING.md>`__.
+2. See our code contribution instructions `here <https://github.com/UDST/urbansim/blob/main/CONTRIBUTING.md>`__.
 3. Contribute your code from a fork or branch by using a Pull Request and
    request a review so it can be considered as an addition to the codebase.
 

--- a/docs/source/maps/index.rst
+++ b/docs/source/maps/index.rst
@@ -61,7 +61,7 @@ The web service will print out each statement it executes.  The website then
 transparently joins the output Pandas series to the shapes and create an
 interactive *slippy* web map using the `Leaflet <http://leafletjs.com/>`_
 Javasript library.  The code for this map is really
-`quite simple <https://github.com/udst/urbansim/tree/master/urbansim/maps>`_
+`quite simple <https://github.com/udst/urbansim/tree/main/urbansim/maps>`_
 - feel free to browse the code and add functionality as required.
 
 To be clear, the website is performing a Pandas aggregation on the fly.


### PR DESCRIPTION
## Summary

- update CI triggers to use the new default `main` branch
- replace obsolete Travis CI and Coveralls badges with the active GitHub Actions badge
- update contribution and documentation links from `master` and `dev` to `main`
- document `dev` and `master` as temporarily retained, deprecated historical branches
- correct the documented tested range to Python 3.10–3.12

## Context

`main` was created from the validated `dev` head after #235 passed the minimum- and latest-dependency CI jobs. The historical `master` branch has no unique file changes relative to the new baseline.

Tracked in #234.